### PR TITLE
Add launch config for debugging tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ coverage/
 npm-debug.log
 .alm/
 dump.json
-.vscode/
+.vscode/*
+!.vscode/launch.json
 scripts/schema.ts
 scripts/schema.json
 .nyc_output/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--timeout",
+                "120000",
+                "--require",
+                "source-map-support/register",
+                "--recursive",
+                "--colors",
+                "--reporter",
+                "progress",
+                "\"./build/test/**/*.js\""
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        }
+    ]
+}


### PR DESCRIPTION
Adds integration with the vscode debugger. As opposed to `npm run test`, this will stop at breakpoints in your code.

- The timeout is in miliseconds. 2 minutes should be more than enough as the tests run in <10 seconds on my machine.

![image](https://user-images.githubusercontent.com/5097067/63653661-23a82f00-c770-11e9-816a-e042ad052288.png)

![image](https://user-images.githubusercontent.com/5097067/63653706-b0eb8380-c770-11e9-8584-62a95a641c2e.png)


