### PR TITLE
Use multiline strings in tests

### DIFF
--- a/test/rules/class_attribute_names.ts
+++ b/test/rules/class_attribute_names.ts
@@ -17,33 +17,45 @@ describe("Rule: class attribute names", function() {
   });
 
   it("issue", function () {
-    const abap = "CLASS zcl_foobar DEFINITION PUBLIC.\n" +
-      "  PUBLIC SECTION. DATA foo TYPE i.\n" +
-      "ENDCLASS. CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.";
+    const abap = `
+CLASS zcl_foobar DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    DATA foo TYPE i.
+ENDCLASS.
+CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("no issue", function () {
-    const abap = "CLASS zcl_foobar DEFINITION PUBLIC.\n" +
-      "  PUBLIC SECTION. DATA mv_foo TYPE i.\n" +
-      "ENDCLASS. CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.";
+    const abap = `
+CLASS zcl_foobar DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    DATA mv_foo TYPE i.
+ENDCLASS.
+CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("issue", function () {
-    const abap = "CLASS zcl_foobar DEFINITION PUBLIC.\n" +
-      "  PUBLIC SECTION. CLASS-DATA foo TYPE i.\n" +
-      "ENDCLASS. CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.";
+    const abap = `
+CLASS zcl_foobar DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    CLASS-DATA foo TYPE i.
+ENDCLASS.
+CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("end position", function () {
-    const abap = "CLASS zcl_foobar DEFINITION PUBLIC.\n" +
-      "  PUBLIC SECTION. CLASS-DATA foo TYPE i.\n" +
-      "ENDCLASS. CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.";
+    const abap = `
+              CLASS zcl_foobar DEFINITION PUBLIC.
+                PUBLIC SECTION.
+                  CLASS-DATA foo TYPE i.
+              ENDCLASS.
+              CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
     expect(issues[0].getEnd().getCol()).to.equal(33);

--- a/test/rules/constructor_visibility_public.ts
+++ b/test/rules/constructor_visibility_public.ts
@@ -4,14 +4,15 @@ import {ConstructorVisibilityPublic} from "../../src/rules";
 import {expect} from "chai";
 
 describe("rule, constructor_visibility_public, one error", function () {
-  const abap = "CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.\n" +
-    "  PRIVATE SECTION.\n" +
-    "    METHODS constructor.\n" +
-    "ENDCLASS.\n" +
-    "CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.\n" +
-    "METHOD constructor.\n" +
-    "ENDMETHOD.\n" +
-    "ENDCLASS.";
+  const abap = `
+CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.
+  PRIVATE SECTION.
+    METHODS constructor.
+ENDCLASS.
+CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.
+  METHOD constructor.
+  ENDMETHOD.
+ENDCLASS.`;
 
   const reg = new Registry().addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.abap", abap)).parse();
   const rule = new ConstructorVisibilityPublic();
@@ -22,14 +23,15 @@ describe("rule, constructor_visibility_public, one error", function () {
 });
 
 describe("rule, constructor_visibility_public, ok", function () {
-  const abap = "CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.\n" +
-    "  PUBLIC SECTION.\n" +
-    "    METHODS constructor.\n" +
-    "ENDCLASS.\n" +
-    "CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.\n" +
-    "METHOD constructor.\n" +
-    "ENDMETHOD.\n" +
-    "ENDCLASS.";
+  const abap = `
+CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.
+  PUBLIC SECTION.
+    METHODS constructor.
+ENDCLASS.
+CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.
+  METHOD constructor.
+  ENDMETHOD.
+ENDCLASS.`;
 
   const reg = new Registry().addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.abap", abap)).parse();
   const rule = new ConstructorVisibilityPublic();

--- a/test/rules/definitions_top.ts
+++ b/test/rules/definitions_top.ts
@@ -2,14 +2,67 @@ import {DefinitionsTop} from "../../src/rules/definitions_top";
 import {testRule} from "./_utils";
 
 const tests = [
-  {abap: "FORM foobar.\ndata: lt_file type foo.\nwrite 'hello'.\nDATA int type i.\nENDFORM.", cnt: 1},
-  {abap: "FORM foobar.\ndata: lt_file type foo.\nDATA int type i.\nwrite 'hello'.\nENDFORM.", cnt: 0},
-  {abap: "FORM foo.\nTYPES: BEGIN OF ty_sort,\nsort TYPE string,\nEND OF ty_sort.\nENDFORM.", cnt: 0},
-  {abap: "FORM foo.\nDATA: BEGIN OF ls_sort,\nsort TYPE string,\nEND OF ls_sort.\nENDFORM.", cnt: 0},
-  {abap: "FORM foo.\nSTATICS: BEGIN OF ss_cached_client,\nusername TYPE string,\n" +
-         "END OF ss_cached_client.\nDATA: lv_http_code TYPE i.\nENDFORM.", cnt: 0},
-  {abap: "FORM foo.\nTYPES: BEGIN OF lty_color_line,\ncolor TYPE lvc_t_scol.\n" +
-         "INCLUDE TYPE gty_status.\nTYPES: END OF lty_color_line.\nENDFORM.", cnt: 0},
+  {
+    abap: `
+FORM foobar.
+	data: lt_file type foo.
+	write 'hello'.
+	DATA int type i.
+ENDFORM.`,
+    cnt: 1,
+  },
+
+  {
+    abap: `
+FORM foobar.
+	data: lt_file type foo.
+	DATA int type i.
+	write 'hello'.
+ENDFORM.`,
+    cnt: 0,
+  },
+
+  {
+    abap: `
+FORM foo.
+	TYPES: BEGIN OF ty_sort,
+				sort TYPE string,
+			END OF ty_sort.
+ENDFORM.`,
+    cnt: 0,
+  },
+
+  {
+    abap: `
+FORM foo.
+	DATA: BEGIN OF ls_sort,
+			sort TYPE string,
+		  END OF ls_sort.
+ENDFORM.`
+    , cnt: 0,
+  },
+
+  {
+    abap: `
+FORM foo.
+	STATICS: BEGIN OF ss_cached_client,
+				username TYPE string,
+			  END OF ss_cached_client.
+			  DATA: lv_http_code TYPE i.
+ENDFORM.`,
+    cnt: 0,
+  },
+
+  {
+    abap: `
+FORM foo.
+	TYPES: BEGIN OF lty_color_line,
+			color TYPE lvc_t_scol.
+			INCLUDE TYPE gty_status.
+	TYPES: END OF lty_color_line.
+ENDFORM.`,
+    cnt: 0,
+  },
 ];
 
 testRule(tests, DefinitionsTop);

--- a/test/rules/empty_line_in_statement.ts
+++ b/test/rules/empty_line_in_statement.ts
@@ -4,9 +4,15 @@ import {EmptyLineinStatement} from "../../src/rules";
 const tests = [
   {abap: "parser error", cnt: 0},
   {abap: "EXIT.", cnt: 0},
-  {abap: "SELECT kunnr INTO lv_kunnr FROM kna1.\nCHECK sy-dbcnt > is_paging-skip.\nENDSELECT.", cnt: 0},
-  {abap: "WRITE: foo,\nbar.", cnt: 0},
-  {abap: "WRITE\n\nbar.", cnt: 1},
+  {abap: `SELECT kunnr INTO lv_kunnr FROM kna1.
+            CHECK sy-dbcnt > is_paging-skip.
+          ENDSELECT.`, cnt: 0},
+  {abap: `WRITE: foo,
+            bar.`, cnt: 0},
+  {abap: `WRITE
+
+
+            bar.`, cnt: 1},
   {abap: "* comment\n\nWRITE bar.", cnt: 0},
 ];
 

--- a/test/rules/exit_or_check.ts
+++ b/test/rules/exit_or_check.ts
@@ -2,10 +2,14 @@ import {ExitOrCheck} from "../../src/rules/exit_or_check";
 import {testRule} from "./_utils";
 
 const tests = [
-  {abap: "LOOP AT lt_usr02 INTO ls_usr02.\nEXIT.\nENDLOOP.", cnt: 0},
+  {abap: `LOOP AT lt_usr02 INTO ls_usr02.
+            EXIT.
+          ENDLOOP.`, cnt: 0},
   {abap: "EXIT.", cnt: 1},
   {abap: "CHECK foo = bar.", cnt: 1},
-  {abap: "SELECT kunnr INTO lv_kunnr FROM kna1.\nCHECK sy-dbcnt > is_paging-skip.\nENDSELECT.", cnt: 0},
+  {abap: `SELECT kunnr INTO lv_kunnr FROM kna1.
+            CHECK sy-dbcnt > is_paging-skip.
+          ENDSELECT.`, cnt: 0},
 ];
 
 testRule(tests, ExitOrCheck);

--- a/test/rules/functional_writing.ts
+++ b/test/rules/functional_writing.ts
@@ -7,14 +7,14 @@ const tests = [
   {abap: "CALL METHOD (lv_class_name)=>jump.", cnt: 0},
   {abap: "CALL METHOD mo_plugin->('SET_FILES').", cnt: 0},
   {abap: "CALL METHOD (method_name) PARAMETER-TABLE parameters.", cnt: 0},
-  {abap: "CLASS ZCL_NOT_AN_EXCEPTION IMPLEMENTATION.\n" +
-    "method CONSTRUCTOR.\n" +
-    "CALL METHOD SUPER->CONSTRUCTOR\n" +
-    "EXPORTING\n" +
-    "TEXTID = TEXTID\n" +
-    "PREVIOUS = PREVIOUS.\n" +
-    "endmethod.\n" +
-    "ENDCLASS.", cnt: 1},
+  {abap: `CLASS ZCL_NOT_AN_EXCEPTION IMPLEMENTATION.
+            method CONSTRUCTOR.
+              CALL METHOD SUPER->CONSTRUCTOR
+                EXPORTING
+                  TEXTID = TEXTID
+                  PREVIOUS = PREVIOUS.
+            endmethod.
+          ENDCLASS.`, cnt: 1},
 ];
 
 testRule(tests, FunctionalWriting);

--- a/test/rules/if_in_if.ts
+++ b/test/rules/if_in_if.ts
@@ -2,32 +2,46 @@ import {IfInIf} from "../../src/rules";
 import {testRule} from "./_utils";
 
 const tests = [
-  {abap: "parser error", cnt: 0},
-  {abap: "IF foo = bar.\nENDIF.", cnt: 0},
-  {abap: "IF foo = bar.\nELSE.\nENDIF.", cnt: 0},
-  {abap: "CHECK foo = bar.", cnt: 0},
-  {abap: "IF foo = bar.\nIF moo = boo.\nENDIF.\nENDIF.", cnt: 1},
-  {abap: "IF foo = bar.\nWRITE bar.\nIF moo = boo.\nENDIF.\nENDIF.", cnt: 0},
-  {abap: "IF foo = bar.\nIF moo = boo.\nENDIF.\nWRITE bar.\nENDIF.", cnt: 0},
-  {abap: "IF foo = bar.\n" +
-    "ELSE.\n" +
-    "  IF moo = boo.\n" +
-    "  ENDIF.\n" +
-    "ENDIF.", cnt: 1},
-  {abap: "IF foo = bar.\n" +
-    "ELSE.\n" +
-    "  IF moo = boo.\n" +
-    "  ELSE.\n" +
-    "  ENDIF.\n" +
-    "ENDIF.", cnt: 1},
-  {abap: "IF foo = bar.\n" +
-    "ELSEIF moo = loo.\n" +
-    "  IF moo = boo.\n" +
-    "  ENDIF.\n" +
-    "ENDIF.", cnt: 0},
-  {abap: "IF foo = bar.\n" +
-    "ELSEIF moo = boo.\n" +
-    "ENDIF.", cnt: 0},
+  {abap: `parser error`, cnt: 0},
+  {abap: `IF foo = bar.
+          ENDIF.`, cnt: 0},
+  {abap: `IF foo = bar.
+          ELSE.
+          ENDIF.`, cnt: 0},
+  {abap: `CHECK foo = bar.`, cnt: 0},
+  {abap: `IF foo = bar.
+            IF moo = boo.
+            ENDIF.
+          ENDIF.`, cnt: 1},
+  {abap: `IF foo = bar.
+            WRITE bar.
+            IF moo = boo.
+            ENDIF.
+          ENDIF.`, cnt: 0},
+  {abap: `IF foo = bar.
+            IF moo = boo.
+            ENDIF.
+            WRITE bar.
+          ENDIF.`, cnt: 0},
+  {abap: `IF foo = bar.
+          ELSE.
+            IF moo = boo.
+            ENDIF.
+          ENDIF.`, cnt: 1},
+  {abap: `IF foo = bar.
+          ELSE.
+            IF moo = boo.
+            ELSE.
+            ENDIF.
+          ENDIF.`, cnt: 1},
+  {abap: `IF foo = bar.
+          ELSEIF moo = loo.
+            IF moo = boo.
+            ENDIF.
+          ENDIF.`, cnt: 0},
+  {abap: `IF foo = bar.
+          ELSEIF moo = boo.
+          ENDIF.`, cnt: 0},
 ];
 
 testRule(tests, IfInIf);

--- a/test/rules/keywords_upper.ts
+++ b/test/rules/keywords_upper.ts
@@ -8,12 +8,12 @@ const tests = [
   {abap: "IF a = b.", cnt: 0},
   {abap: "IF A = b.", cnt: 1}, // "A" should be lower case
   {abap: "CLASS ZCL_ABAPGIT_ZLIB_STREAM IMPLEMENTATION.", cnt: 0}, // txn SE80 upper cases the keyword when saving
-  {abap: "CALL FUNCTION 'ZMOOBOO'\n" +
-  "EXPORTING\n" +
-  "  iv_fild     = lv_value\n" +
-  "EXCEPTIONS\n" +
-  "  invalid_boo = 1\n" +
-  "  OTHERS      = 2.", cnt: 0},
+  {abap: `CALL FUNCTION 'ZMOOBOO'
+  EXPORTING
+    iv_fild     = lv_value
+  EXCEPTIONS
+    invalid_boo = 1
+    OTHERS      = 2.`, cnt: 0},
   {abap: "LOOP AT SCREEN.", cnt: 0},
   {abap: "MODIFY SCREEN.",  cnt: 0},
   {abap: "FIELD-SYMBOLS <lv_dst> TYPE ANY.", cnt: 0}, // todo, "ANY" should be lower case

--- a/test/rules/local_variable_names.ts
+++ b/test/rules/local_variable_names.ts
@@ -17,70 +17,109 @@ describe("Rule: local variable names", function() {
   });
 
   it("ok", function () {
-    const abap = "FORM foobar. DATA lv_moo TYPE i. ENDFORM.";
+    const abap = `
+FORM foobar.
+    DATA lv_moo TYPE i.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("issue, FORM", function () {
-    const abap = "FORM foobar. DATA moo TYPE i. ENDFORM.";
+    const abap = `
+FORM foobar.
+  DATA moo TYPE i.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("issue, METHOD", function () {
-    const abap = "CLASS foo IMPLEMENTATION. METHOD foobar. DATA moo TYPE i. ENDMETHOD. ENDCLASS.";
+    const abap = `
+CLASS foo IMPLEMENTATION.
+    METHOD foobar.
+      DATA moo TYPE i.
+    ENDMETHOD.
+ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("issue, Function Module", function () {
-    const abap = "FUNCTION foo. DATA moo TYPE i. ENDFUNCTION.";
+    const abap = `
+FUNCTION foo.
+  DATA moo TYPE i.
+ENDFUNCTION.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("issue, FORM, fieldsymbol", function () {
-    const abap = "FORM foobar. FIELD-SYMBOL <moo> TYPE i. ENDFORM.";
+    const abap = `
+FORM foobar.
+  FIELD-SYMBOL <moo> TYPE i.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("ok, FORM, fieldsymbol", function () {
-    const abap = "FORM foobar. FIELD-SYMBOL <lv_moo> TYPE i. ENDFORM.";
+    const abap = `
+FORM foobar.
+  FIELD-SYMBOL <lv_moo> TYPE i.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("ok, FORM, DATA BEGIN OF", function () {
-    const abap = "FORM foobar. DATA: BEGIN OF ls_foo, moob TYPE i, END OF ls_foo. ENDFORM.";
+    const abap = `
+FORM foobar.
+  DATA: BEGIN OF ls_foo,
+                 moob TYPE i,
+        END OF ls_foo.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("issue, FORM, DATA BEGIN OF", function () {
-    const abap = "FORM foobar. DATA: BEGIN OF foo, moob TYPE i, END OF foo. ENDFORM.";
+    const abap = `
+FORM foobar.
+  DATA: BEGIN OF foo,
+            moob TYPE i,
+        END OF foo.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("issue, local constant", function () {
-    const abap = "FORM foobar. CONSTANTS foo TYPE c VALUE 'A' LENGTH 1. ENDFORM.";
+    const abap = `
+FORM foobar.
+  CONSTANTS foo TYPE c VALUE 'A' LENGTH 1.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });
 
   it("ok, local constant", function () {
-    const abap = "FORM foobar. CONSTANTS lc_foo TYPE c VALUE 'A' LENGTH 1. ENDFORM.";
+    const abap = `
+FORM foobar.
+  CONSTANTS lc_foo TYPE c VALUE 'A' LENGTH 1.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("ok, local constant structure", function () {
-    const abap = "FORM foobar. CONSTANTS: BEGIN OF lc_parameter_type,\n" +
-      "import TYPE vepparamtype VALUE 'I',\n" +
-      "export TYPE vepparamtype VALUE 'O',\n" +
-      "END OF lc_parameter_type. ENDFORM.";
+    const abap = `
+FORM foobar.
+  CONSTANTS: BEGIN OF lc_parameter_type,
+              import TYPE vepparamtype VALUE 'I',
+              export TYPE vepparamtype VALUE 'O',
+              END OF lc_parameter_type.
+ENDFORM.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });

--- a/test/rules/method_length.ts
+++ b/test/rules/method_length.ts
@@ -7,157 +7,157 @@ const tests = [
   {abap: "METHOD foobar. ENDMETHOD.", cnt: 0},
   {abap: "METHOD foobar. WRITE foo. ENDMETHOD.", cnt: 0},
 
-  {abap: "METHOD foobar.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "WRITE foo.\n" +
-    "ENDMETHOD.", cnt: 1},
+  {abap: `METHOD foobar.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  WRITE foo.
+  ENDMETHOD.`, cnt: 1},
 ];
 
 testRule(tests, MethodLength);

--- a/test/rules/method_parameter_names.ts
+++ b/test/rules/method_parameter_names.ts
@@ -9,115 +9,126 @@ function findIssues(abap: string, filename: string) {
   return rule.run(reg.getObjects()[0], reg);
 }
 
-describe("Rule: method parameter names", function() {
-  it("positive 1", function () {
-    const abap = "INTERFACE zif_foobar PUBLIC.\n" +
-      "  METHODS method1 IMPORTING foo TYPE i.\n" +
-      "ENDINTERFACE.";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+describe(`Rule: method parameter names`, function() {
+  it(`positive 1`, function () {
+    const abap = `
+INTERFACE zif_foobar PUBLIC.
+  METHODS method1 IMPORTING foo TYPE i.
+ENDINTERFACE.`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(1);
   });
 
-  it("negative, 1", function () {
-    const abap = "INTERFACE zif_foobar PUBLIC.\n" +
-      "  METHODS method1 IMPORTING !iv_foo TYPE i.\n" +
-      "ENDINTERFACE.";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+  it(`negative, 1`, function () {
+    const abap = `
+INTERFACE zif_foobar PUBLIC.
+  METHODS method1 IMPORTING !iv_foo TYPE i.
+ENDINTERFACE.`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("negative", function () {
-    const abap = "INTERFACE zif_foobar PUBLIC.\n" +
-      "  METHODS method1 IMPORTING iv_foo TYPE i.\n" +
-      "ENDINTERFACE.";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+  it(`negative`, function () {
+    const abap = `
+INTERFACE zif_foobar PUBLIC.
+  METHODS method1 IMPORTING iv_foo TYPE i.
+ENDINTERFACE.`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("no methods, interface", function () {
-    const abap = "INTERFACE zif_foobar PUBLIC.\n" +
-      "ENDINTERFACE.";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+  it(`no methods, interface`, function () {
+    const abap = `
+INTERFACE zif_foobar PUBLIC.
+ENDINTERFACE.`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("no methods, class", function () {
-    const abap = "CLASS zcl_foobar PUBLIC.\n" +
-      "ENDCLASS.";
-    const issues = findIssues(abap, "zif_foobar.clas.abap");
+  it(`no methods, class`, function () {
+    const abap = `
+CLASS zcl_foobar PUBLIC.
+ENDCLASS.`;
+    const issues = findIssues(abap, `zif_foobar.clas.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("parser error, class", function () {
-    const abap = "sdfsd sdf sdfsd fd";
-    const issues = findIssues(abap, "zif_foobar.clas.abap");
+  it(`parser error, class`, function () {
+    const abap = `sdfsd sdf sdfsd fd`;
+    const issues = findIssues(abap, `zif_foobar.clas.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("parser error, interface", function () {
-    const abap = "sdfsd sdf sdfsd fd";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+  it(`parser error, interface`, function () {
+    const abap = `sdfsd sdf sdfsd fd`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("skip exception", function () {
-    const abap = "CLASS zcx_abapgit_exception DEFINITION\n" +
-      "PUBLIC\n" +
-      "INHERITING FROM cx_static_check\n" +
-      "CREATE PUBLIC.\n" +
-      "PUBLIC SECTION.\n" +
-      "METHODS constructor IMPORTING foo TYPE C OPTIONAL.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcx_abapgit_exception IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+  it(`skip exception`, function () {
+    const abap = `
+CLASS zcx_abapgit_exception DEFINITION
+PUBLIC
+INHERITING FROM cx_static_check
+CREATE PUBLIC.
+  PUBLIC SECTION.
+    METHODS constructor IMPORTING foo TYPE C OPTIONAL.
+ENDCLASS.
+CLASS zcx_abapgit_exception IMPLEMENTATION.
+ENDCLASS.`;
 
-    const issues = findIssues(abap, "zcx_abapgit_exception.clas.abap");
+    const issues = findIssues(abap, `zcx_abapgit_exception.clas.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("skip p_task", function () {
-    const abap = "INTERFACE zif_foobar PUBLIC.\n" +
-      "  METHODS method1 IMPORTING p_task TYPE i.\n" +
-      "ENDINTERFACE.";
-    const issues = findIssues(abap, "zif_foobar.intf.abap");
+  it(`skip p_task`, function () {
+    const abap = `
+INTERFACE zif_foobar PUBLIC.
+  METHODS method1 IMPORTING p_task TYPE i.
+ENDINTERFACE.`;
+    const issues = findIssues(abap, `zif_foobar.intf.abap`);
     expect(issues.length).to.equal(0);
   });
 
-  it("positive, instance method", function () {
-    const abap = "CLASS lcl_foobar DEFINITION.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    METHODS method1 IMPORTING foo TYPE i.\n" +
-      "ENDCLASS.";
-    const issues = findIssues(abap, "foobar.prog.abap");
+  it(`positive, instance method`, function () {
+    const abap = `
+CLASS lcl_foobar DEFINITION.
+  PUBLIC SECTION.
+    METHODS method1 IMPORTING foo TYPE i.
+ENDCLASS.`;
+    const issues = findIssues(abap, `foobar.prog.abap`);
     expect(issues.length).to.equal(1);
   });
 
-  it("positive, static method", function () {
-    const abap = "CLASS lcl_foobar DEFINITION.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    CLASS-METHODS method1 IMPORTING foo TYPE i.\n" +
-      "ENDCLASS.";
-    const issues = findIssues(abap, "foobar.prog.abap");
+  it(`positive, static method`, function () {
+    const abap = `
+CLASS lcl_foobar DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS method1 IMPORTING foo TYPE i.
+ENDCLASS.`;
+    const issues = findIssues(abap, `foobar.prog.abap`);
     expect(issues.length).to.equal(1);
   });
 
-  it("end position", function () {
-    const abap = "CLASS lcl_foobar DEFINITION.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    CLASS-METHODS method1 IMPORTING foo TYPE i.\n" +
-      "ENDCLASS.";
-    const issues = findIssues(abap, "foobar.prog.abap");
+  it(`end position`, function () {
+    const abap = `
+CLASS lcl_foobar DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS method1 IMPORTING foo TYPE i.
+ENDCLASS.`;
+    const issues = findIssues(abap, `foobar.prog.abap`);
     expect(issues.length).to.equal(1);
     expect(issues[0].getEnd().getCol()).to.equal(40);
   });
 
-  it("ignore event handler parameter names", function () {
-    const abap = "CLASS lcl_foobar DEFINITION.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    CLASS-METHODS on_link_click FOR EVENT link_click OF cl_salv_events_table\n" +
-      " IMPORTING row column.\n" +
-      "ENDCLASS.";
-    const issues = findIssues(abap, "foobar.prog.abap");
+  it(`ignore event handler parameter names`, function () {
+    const abap = `
+CLASS lcl_foobar DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS on_link_click FOR EVENT link_click OF cl_salv_events_table
+  IMPORTING row column.
+ENDCLASS.`;
+    const issues = findIssues(abap, `foobar.prog.abap`);
     expect(issues.length).to.equal(0);
   });
 

--- a/test/rules/mix_returning.ts
+++ b/test/rules/mix_returning.ts
@@ -17,31 +17,34 @@ describe("Rule: local variable names", function() {
   });
 
   it("ok", function () {
-    const abap = "CLASS zcl_abapgit_object_enho_class DEFINITION.\n" +
-      "PUBLIC SECTION.\n" +
-      "  METHODS:\n" +
-      "   foobar.\n" +
-      "ENDCLASS.";
+    const abap = `
+CLASS zcl_abapgit_object_enho_class DEFINITION.
+  PUBLIC SECTION.
+    METHODS:
+      foobar.
+ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("ok", function () {
-    const abap = "CLASS zcl_abapgit_object_enho_class DEFINITION.\n" +
-      "PUBLIC SECTION.\n" +
-      "  METHODS:\n" +
-      "   foobar RETURNING VALUE(rv_string) TYPE string.\n" +
-      "ENDCLASS.";
+    const abap = `
+CLASS zcl_abapgit_object_enho_class DEFINITION.
+  PUBLIC SECTION.
+    METHODS:
+      foobar RETURNING VALUE(rv_string) TYPE string.
+ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(0);
   });
 
   it("issue", function () {
-    const abap = "CLASS zcl_abapgit_object_enho_class DEFINITION.\n" +
-      "PUBLIC SECTION.\n" +
-      "  METHODS:\n" +
-      "   foobar EXPORTING foo TYPE i RETURNING VALUE(rv_string) TYPE string.\n" +
-      "ENDCLASS.";
+    const abap = `
+CLASS zcl_abapgit_object_enho_class DEFINITION.
+  PUBLIC SECTION.
+    METHODS:
+      foobar EXPORTING foo TYPE i RETURNING VALUE(rv_string) TYPE string.
+ENDCLASS.`;
     const issues = findIssues(abap);
     expect(issues.length).to.equal(1);
   });

--- a/test/rules/remove_descriptions.ts
+++ b/test/rules/remove_descriptions.ts
@@ -4,37 +4,38 @@ import {RemoveDescriptions} from "../../src/rules";
 import {expect} from "chai";
 
 describe("rule, remove_descriptions, one error", function () {
-  const xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-    "<abapGit version=\"v1.0.0\" serializer=\"LCL_OBJECT_CLAS\" serializer_version=\"v1.0.0\">\n" +
-    " <asx:abap xmlns:asx=\"http://www.sap.com/abapxml\" version=\"1.0\">\n" +
-    "  <asx:values>\n" +
-    "   <VSEOCLASS>\n" +
-    "    <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "    <VERSION>1</VERSION>\n" +
-    "    <LANGU>E</LANGU>\n" +
-    "    <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    <STATE>1</STATE>\n" +
-    "    <CLSCCINCL>X</CLSCCINCL>\n" +
-    "    <FIXPT>X</FIXPT>\n" +
-    "    <UNICODE>X</UNICODE>\n" +
-    "    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>\n" +
-    "   </VSEOCLASS>\n" +
-    "   <DESCRIPTIONS>\n" +
-    "    <SEOCOMPOTX>\n" +
-    "     <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "     <CMPNAME>GO_PERSIST</CMPNAME>\n" +
-    "     <LANGU>E</LANGU>\n" +
-    "     <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    </SEOCOMPOTX>\n" +
-    "   </DESCRIPTIONS>\n" +
-    "  </asx:values>\n" +
-    " </asx:abap>\n" +
-    "</abapGit>";
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+    <abapGit version="v1.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0">
+     <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+      <asx:values>
+       <VSEOCLASS>
+        <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+        <VERSION>1</VERSION>
+        <LANGU>E</LANGU>
+        <DESCRIPT>Settings</DESCRIPT>
+        <STATE>1</STATE>
+        <CLSCCINCL>X</CLSCCINCL>
+        <FIXPT>X</FIXPT>
+        <UNICODE>X</UNICODE>
+        <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+       </VSEOCLASS>
+       <DESCRIPTIONS>
+        <SEOCOMPOTX>
+         <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+         <CMPNAME>GO_PERSIST</CMPNAME>
+         <LANGU>E</LANGU>
+         <DESCRIPT>Settings</DESCRIPT>
+        </SEOCOMPOTX>
+       </DESCRIPTIONS>
+      </asx:values>
+     </asx:abap>
+    </abapGit>`;
 
-  const abap = "CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.\n" +
-    "ENDCLASS.\n" +
-    "CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.\n" +
-    "ENDCLASS.";
+  const abap = `
+CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.
+ENDCLASS.
+CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.
+ENDCLASS.`;
 
   const reg = new Registry().addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.xml", xml));
   reg.addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.abap", abap));
@@ -47,29 +48,30 @@ describe("rule, remove_descriptions, one error", function () {
 });
 
 describe("rule, remove_descriptions, no error", function () {
-  const xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-    "<abapGit version=\"v1.0.0\" serializer=\"LCL_OBJECT_CLAS\" serializer_version=\"v1.0.0\">\n" +
-    " <asx:abap xmlns:asx=\"http://www.sap.com/abapxml\" version=\"1.0\">\n" +
-    "  <asx:values>\n" +
-    "   <VSEOCLASS>\n" +
-    "    <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "    <VERSION>1</VERSION>\n" +
-    "    <LANGU>E</LANGU>\n" +
-    "    <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    <STATE>1</STATE>\n" +
-    "    <CLSCCINCL>X</CLSCCINCL>\n" +
-    "    <FIXPT>X</FIXPT>\n" +
-    "    <UNICODE>X</UNICODE>\n" +
-    "    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>\n" +
-    "   </VSEOCLASS>\n" +
-    "  </asx:values>\n" +
-    " </asx:abap>\n" +
-    "</abapGit>";
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+    <abapGit version="v1.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0">
+     <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+      <asx:values>
+       <VSEOCLASS>
+        <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+        <VERSION>1</VERSION>
+        <LANGU>E</LANGU>
+        <DESCRIPT>Settings</DESCRIPT>
+        <STATE>1</STATE>
+        <CLSCCINCL>X</CLSCCINCL>
+        <FIXPT>X</FIXPT>
+        <UNICODE>X</UNICODE>
+        <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+       </VSEOCLASS>
+      </asx:values>
+     </asx:abap>
+    </abapGit>`;
 
-  const abap = "CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.\n" +
-    "ENDCLASS.\n" +
-    "CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.\n" +
-    "ENDCLASS.";
+  const abap = `
+CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.
+ENDCLASS.
+CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.
+ENDCLASS.`;
 
   const reg = new Registry().addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.xml", xml));
   reg.addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.abap", abap));
@@ -82,43 +84,42 @@ describe("rule, remove_descriptions, no error", function () {
 });
 
 describe("rule, remove_descriptions, 2 errors", function () {
-  const xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-    "<abapGit version=\"v1.0.0\" serializer=\"LCL_OBJECT_CLAS\" serializer_version=\"v1.0.0\">\n" +
-    " <asx:abap xmlns:asx=\"http://www.sap.com/abapxml\" version=\"1.0\">\n" +
-    "  <asx:values>\n" +
-    "   <VSEOCLASS>\n" +
-    "    <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "    <VERSION>1</VERSION>\n" +
-    "    <LANGU>E</LANGU>\n" +
-    "    <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    <STATE>1</STATE>\n" +
-    "    <CLSCCINCL>X</CLSCCINCL>\n" +
-    "    <FIXPT>X</FIXPT>\n" +
-    "    <UNICODE>X</UNICODE>\n" +
-    "    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>\n" +
-    "   </VSEOCLASS>\n" +
-    "   <DESCRIPTIONS>\n" +
-    "    <SEOCOMPOTX>\n" +
-    "     <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "     <CMPNAME>GO_PERSIST</CMPNAME>\n" +
-    "     <LANGU>E</LANGU>\n" +
-    "     <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    </SEOCOMPOTX>\n" +
-    "    <SEOCOMPOTX>\n" +
-    "     <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>\n" +
-    "     <CMPNAME>SOMETHING_ELSE</CMPNAME>\n" +
-    "     <LANGU>E</LANGU>\n" +
-    "     <DESCRIPT>Settings</DESCRIPT>\n" +
-    "    </SEOCOMPOTX>\n" +
-    "   </DESCRIPTIONS>\n" +
-    "  </asx:values>\n" +
-    " </asx:abap>\n" +
-    "</abapGit>";
-
-  const abap = "CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.\n" +
-    "ENDCLASS.\n" +
-    "CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.\n" +
-    "ENDCLASS.";
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+    <abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+     <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+      <asx:values>
+       <VSEOCLASS>
+        <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+        <VERSION>1</VERSION>
+        <LANGU>E</LANGU>
+        <DESCRIPT>Settings</DESCRIPT>
+        <STATE>1</STATE>
+        <CLSCCINCL>X</CLSCCINCL>
+        <FIXPT>X</FIXPT>
+        <UNICODE>X</UNICODE>
+        <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+       </VSEOCLASS>
+       <DESCRIPTIONS>
+        <SEOCOMPOTX>
+         <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+         <CMPNAME>GO_PERSIST</CMPNAME>
+         <LANGU>E</LANGU>
+         <DESCRIPT>Settings</DESCRIPT>
+        </SEOCOMPOTX>
+        <SEOCOMPOTX>
+         <CLSNAME>ZCL_ABAPGIT_PERSIST_SETTINGS</CLSNAME>
+         <CMPNAME>SOMETHING_ELSE</CMPNAME>
+         <LANGU>E</LANGU>
+         <DESCRIPT>Settings</DESCRIPT>
+        </SEOCOMPOTX>
+       </DESCRIPTIONS>
+      </asx:values>
+     </asx:abap>
+    </abapGit>`;
+  const abap = `CLASS zcl_abapgit_persist_settings DEFINITION PUBLIC CREATE PRIVATE.
+    ENDCLASS.
+    CLASS ZCL_ABAPGIT_PERSIST_SETTINGS IMPLEMENTATION.
+    ENDCLASS.`;
 
   const reg = new Registry().addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.xml", xml));
   reg.addFile(new MemoryFile("zcl_abapgit_persist_settings.clas.abap", abap));

--- a/test/rules/rfc_error_handling.ts
+++ b/test/rules/rfc_error_handling.ts
@@ -5,16 +5,17 @@ const tests = [
   {abap: "parser error", cnt: 0},
   {abap: "CALL FUNCTION 'MOO'.", cnt: 0},
   {abap: "CALL FUNCTION 'MOO' DESTINATION 'BAR'.", cnt: 1},
-  {abap: "CALL FUNCTION 'MOO' DESTINATION 'BAR'\n" +
-    "  EXCEPTIONS\n" +
-    "    system_failure        = 1 MESSAGE lv_msg\n" +
-    "    communication_failure = 2 MESSAGE lv_msg\n" +
-    "    resource_failure      = 3.", cnt: 0},
-  {abap: "CALL FUNCTION 'MOO' DESTINATION 'BAR'\n" +
-    "  EXCEPTIONS\n" +
-    "    mooo        = 1 MESSAGE lv_msg\n" +
-    "    communication_failure = 2 MESSAGE lv_msg\n" +
-    "    resource_failure      = 3.", cnt: 1},
+  {abap: `CALL FUNCTION 'MOO' DESTINATION 'BAR'
+      EXCEPTIONS
+        system_failure        = 1 MESSAGE lv_msg
+        communication_failure = 2 MESSAGE lv_msg
+        resource_failure      = 3.`, cnt: 0},
+
+  {abap: `CALL FUNCTION 'MOO' DESTINATION 'BAR'
+      EXCEPTIONS
+        mooo        = 1 MESSAGE lv_msg
+        communication_failure = 2 MESSAGE lv_msg
+        resource_failure      = 3.`, cnt: 1},
 ];
 
 testRule(tests, RFCErrorHandling);

--- a/test/rules/syntax/begin_end_names.ts
+++ b/test/rules/syntax/begin_end_names.ts
@@ -12,14 +12,14 @@ const tests = [
   {abap: "DATA: BEGIN OF moo, dsf TYPE string, END OF bar.", cnt: 1},
   {abap: "DATA: BEGIN OF moo, dsf TYPE string, END OF moo.", cnt: 0},
 
-  {abap: "class foo definition.\n" +
-    "public section.\n" +
-    "CLASS-DATA: BEGIN OF moo, dsf TYPE string, END OF bar.\n" +
-    "endclass.", cnt: 1},
-  {abap: "class foo definition.\n" +
-    "public section.\n" +
-    "CLASS-DATA: BEGIN OF moo, dsf TYPE string, END OF moo.\n" +
-    "endclass.", cnt: 0},
+  {abap: `class foo definition.
+    public section.
+    CLASS-DATA: BEGIN OF moo, dsf TYPE string, END OF bar.
+    endclass.`, cnt: 1},
+  {abap: `class foo definition.
+    public section.
+    CLASS-DATA: BEGIN OF moo, dsf TYPE string, END OF moo.
+    endclass.`, cnt: 0},
 
   {abap: "STATICS: BEGIN OF moo, dsf TYPE string, END OF bar.", cnt: 1},
   {abap: "STATICS: BEGIN OF moo, dsf TYPE string, END OF moo.", cnt: 0},

--- a/test/rules/syntax/check_transformation_exists.ts
+++ b/test/rules/syntax/check_transformation_exists.ts
@@ -24,28 +24,28 @@ describe("Rules, check_transformation_exists", function () {
   });
 
   it("not found", () => {
-    const contents = "REPORT zfoo.\n" +
-      "CALL TRANSFORMATION id\n" +
-      "  SOURCE (lt_stab)\n" +
-      "  RESULT XML li_doc.";
+    const contents = `REPORT zfoo.
+      CALL TRANSFORMATION id
+        SOURCE (lt_stab)
+        RESULT XML li_doc.`;
     const issues = runMulti([{filename: "zfoo.prog.abap", contents}]);
     expect(issues.length).to.equals(1);
   });
 
   it("dynamic, no error", () => {
-    const contents = "REPORT zfoo.\n" +
-      "CALL TRANSFORMATION (fsd)\n" +
-      "  SOURCE (lt_stab)\n" +
-      "  RESULT XML li_doc.";
+    const contents = `REPORT zfoo.
+      CALL TRANSFORMATION (fsd)
+        SOURCE (lt_stab)
+        RESULT XML li_doc.`;
     const issues = runMulti([{filename: "zfoo.prog.abap", contents}]);
     expect(issues.length).to.equals(0);
   });
 
   it("found, ok", () => {
-    const contents = "REPORT zfoo.\n" +
-      "CALL TRANSFORMATION id\n" +
-      "  SOURCE (lt_stab)\n" +
-      "  RESULT XML li_doc.";
+    const contents = `REPORT zfoo.
+      CALL TRANSFORMATION id
+        SOURCE (lt_stab)
+        RESULT XML li_doc.`;
     const issues = runMulti([
       {filename: "zfoo.prog.abap", contents},
       {filename: "id.xslt.xml", contents: "<foo></foo>"}]);

--- a/test/rules/syntax/implement_methods.ts
+++ b/test/rules/syntax/implement_methods.ts
@@ -24,79 +24,84 @@ describe("Rules, implement_methods", function () {
   });
 
   it("normal class, no methods", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const contents =
+    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+     ENDCLASS.
+     CLASS zcl_foobar IMPLEMENTATION.
+     ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(0);
   });
 
   it("local class, implementation part not found", () => {
-    const contents = "REPORT zrep.\n" +
-      "CLASS lcl_foobar DEFINITION.\n" +
-      "ENDCLASS.\n";
+    const contents =
+    `REPORT zrep.
+     CLASS lcl_foobar DEFINITION.
+     ENDCLASS.`;
     const issues = runMulti([{filename: "zrep.prog.abap", contents}]);
     expect(issues.length).to.equals(1);
   });
 
   it("normal class, missing implementation", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    METHODS foobar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const contents =
+    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          METHODS foobar.
+     ENDCLASS.
+     CLASS zcl_foobar IMPLEMENTATION.
+     ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(1);
   });
 
   it("normal class, method implemented", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    METHODS foobar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "  METHOD foobar.\n" +
-      "  ENDMETHOD.\n" +
-      "ENDCLASS.";
+    const contents =
+    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+       PUBLIC SECTION.
+         METHODS foobar.
+     ENDCLASS.
+     CLASS zcl_foobar IMPLEMENTATION.
+       METHOD foobar.
+       ENDMETHOD.
+      ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(0);
   });
 
   it("abstract method", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    METHODS foobar ABSTRACT.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const contents =
+    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+      PUBLIC SECTION.
+        METHODS foobar ABSTRACT.
+     ENDCLASS.
+     CLASS zcl_foobar IMPLEMENTATION.
+     ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(0);
   });
 
   it("abstract method, do not implement", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    METHODS foobar ABSTRACT.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "  METHOD foobar.\n" +
-      "  ENDMETHOD.\n" +
-      "ENDCLASS.";
+    const contents = `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          METHODS foobar ABSTRACT.
+      ENDCLASS.
+      CLASS zcl_foobar IMPLEMENTATION.
+        METHOD foobar.
+        ENDMETHOD.
+      ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(1);
   });
 
   it("global class with local classes", () => {
-    const main = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.";
-    const imp = "CLASS lcl_foo IMPLEMENTATION.\n" +
-      "ENDCLASS.";
-    const def = "CLASS lcl_foo DEFINITION.\n" +
-      "ENDCLASS.";
+    const main = `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+      ENDCLASS.
+      CLASS zcl_foobar IMPLEMENTATION.
+      ENDCLASS.`;
+    const imp = `CLASS lcl_foo IMPLEMENTATION.
+      ENDCLASS.`;
+    const def = `CLASS lcl_foo DEFINITION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foobar.clas.locals_imp.abap", contents: imp},
       {filename: "zcl_foobar.clas.locals_def.abap", contents: def},
@@ -106,27 +111,27 @@ describe("Rules, implement_methods", function () {
   });
 
   it("implemented interface not found", () => {
-    const clas = "CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const clas = `CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          INTERFACES: zif_bar.
+      ENDCLASS.
+      CLASS zcl_foo IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foo.clas.abap", contents: clas}]);
     expect(issues.length).to.equals(1);
   });
 
   it("implement methods from interface, error, not implemented", () => {
-    const intf = "INTERFACE zif_bar PUBLIC.\n" +
-      "  METHODS: foobar.\n" +
-      "ENDINTERFACE.\n";
-    const clas = "CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const intf = `INTERFACE zif_bar PUBLIC.
+        METHODS: foobar.
+      ENDINTERFACE.\n`;
+    const clas = `CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          INTERFACES: zif_bar.
+      ENDCLASS.
+      CLASS zcl_foo IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foo.clas.abap", contents: clas},
       {filename: "zif_bar.intf.abap", contents: intf}]);
@@ -134,15 +139,15 @@ describe("Rules, implement_methods", function () {
   });
 
   it("interface contains syntax error, ignore", () => {
-    const intf = "INTERFsdffsdACE zif_bar PUBLIC.\n" +
-      "  METHODS: foobar.\n" +
-      "ENDINTERFACE.\n";
-    const clas = "CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const intf = `INTERFsdffsdACE zif_bar PUBLIC.
+        METHODS: foobar.
+      ENDINTERFACE.\n`;
+    const clas = `CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          INTERFACES: zif_bar.
+      ENDCLASS.
+      CLASS zcl_foo IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foo.clas.abap", contents: clas},
       {filename: "zif_bar.intf.abap", contents: intf}]);
@@ -150,17 +155,17 @@ describe("Rules, implement_methods", function () {
   });
 
   it("implement methods from interface, implemented", () => {
-    const intf = "INTERFACE zif_bar PUBLIC.\n" +
-      "  METHODS: foobar.\n" +
-      "ENDINTERFACE.\n";
-    const clas = "CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "  METHOD zif_bar~foobar.\n" +
-      "  ENDMETHOD.\n" +
-      "ENDCLASS.";
+    const intf = `INTERFACE zif_bar PUBLIC.
+        METHODS: foobar.
+      ENDINTERFACE.\n`;
+    const clas = `CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          INTERFACES: zif_bar.
+      ENDCLASS.
+      CLASS zcl_foo IMPLEMENTATION.
+        METHOD zif_bar~foobar.
+        ENDMETHOD.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foo.clas.abap", contents: clas},
       {filename: "zif_bar.intf.abap", contents: intf}]);
@@ -168,18 +173,20 @@ describe("Rules, implement_methods", function () {
   });
 
   it("implement methods from interface, implemented by ALIAS", () => {
-    const intf = "INTERFACE zif_bar PUBLIC.\n" +
-      "  METHODS: foobar.\n" +
-      "ENDINTERFACE.\n";
-    const clas = "CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "    ALIASES: foobar FOR zif_bar~foobar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "  METHOD foobar.\n" +
-      "  ENDMETHOD.\n" +
-      "ENDCLASS.";
+    const intf =
+    `INTERFACE zif_bar PUBLIC.
+        METHODS: foobar.
+      ENDINTERFACE.\n`;
+    const clas =
+    `CLASS zcl_foo DEFINITION PUBLIC FINAL CREATE PUBLIC.
+        PUBLIC SECTION.
+          INTERFACES: zif_bar.
+          ALIASES: foobar FOR zif_bar~foobar.
+      ENDCLASS.
+      CLASS zcl_foo IMPLEMENTATION.
+        METHOD foobar.
+        ENDMETHOD.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foo.clas.abap", contents: clas},
       {filename: "zif_bar.intf.abap", contents: intf}]);
@@ -187,15 +194,16 @@ describe("Rules, implement_methods", function () {
   });
 
   it("PROG, local intf and class", () => {
-    const prog = "REPORT zfoobar.\n" +
-      "INTERFACE zif_bar.\n" +
-      "ENDINTERFACE.\n" +
-      "CLASS zcl_foo DEFINITION.\n" +
-      "  PUBLIC SECTION.\n" +
-      "    INTERFACES: zif_bar.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foo IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const prog = `
+    REPORT zfoobar.
+    INTERFACE zif_bar.
+    ENDINTERFACE.
+    CLASS zcl_foo DEFINITION.
+      PUBLIC SECTION.
+        INTERFACES: zif_bar.
+    ENDCLASS.
+    CLASS zcl_foo IMPLEMENTATION.
+    ENDCLASS.`;
     const issues = runMulti([
       {filename: "zfoobar.prog.abap", contents: prog}]);
     expect(issues.length).to.equals(0);

--- a/test/rules/syntax/superclass_final.ts
+++ b/test/rules/syntax/superclass_final.ts
@@ -24,25 +24,27 @@ describe("Rules, superclass final rule", function () {
   });
 
   it("normal class", () => {
-    const contents = "CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+    const contents =
+      `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+      ENDCLASS.
+      CLASS zcl_foobar IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([{filename: "cl_foo.clas.abap", contents}]);
     expect(issues.length).to.equals(0);
   });
 
   it("superclass final", () => {
     const clas =
-      "CLASS zcl_foobar DEFINITION PUBLIC INHERITING FROM zcl_super FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.\n";
+      `CLASS zcl_foobar DEFINITION PUBLIC
+        INHERITING FROM zcl_super FINAL CREATE PUBLIC.
+      ENDCLASS.
+      CLASS zcl_foobar IMPLEMENTATION.
+      ENDCLASS.`;
     const sup =
-      "CLASS zcl_super DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS ZCL_SUPER IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+      `CLASS zcl_super DEFINITION PUBLIC FINAL CREATE PUBLIC.
+      ENDCLASS.
+      CLASS ZCL_SUPER IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foobar.clas.abap", contents: clas},
       {filename: "zcl_super.clas.abap", contents: sup}]);
@@ -51,15 +53,16 @@ describe("Rules, superclass final rule", function () {
 
   it("superclass not final", () => {
     const clas =
-      "CLASS zcl_foobar DEFINITION PUBLIC INHERITING FROM zcl_super FINAL CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS zcl_foobar IMPLEMENTATION.\n" +
-      "ENDCLASS.\n";
+      `CLASS zcl_foobar DEFINITION PUBLIC
+        INHERITING FROM zcl_super FINAL CREATE PUBLIC.
+      ENDCLASS.
+      CLASS zcl_foobar IMPLEMENTATION.
+      ENDCLASS.`;
     const sup =
-      "CLASS zcl_super DEFINITION PUBLIC CREATE PUBLIC.\n" +
-      "ENDCLASS.\n" +
-      "CLASS ZCL_SUPER IMPLEMENTATION.\n" +
-      "ENDCLASS.";
+      `CLASS zcl_super DEFINITION PUBLIC CREATE PUBLIC.
+      ENDCLASS.
+      CLASS ZCL_SUPER IMPLEMENTATION.
+      ENDCLASS.`;
     const issues = runMulti([
       {filename: "zcl_foobar.clas.abap", contents: clas},
       {filename: "zcl_super.clas.abap", contents: sup}]);

--- a/test/rules/unreachable_code.ts
+++ b/test/rules/unreachable_code.ts
@@ -4,12 +4,27 @@ import {testRule} from "./_utils";
 const tests = [
   {abap: "parser error", cnt: 0},
   {abap: "WRITE 'hello'.", cnt: 0},
-  {abap: "RETURN.\nWRITE 'hello'.", cnt: 1},
-  {abap: "IF foo = bar.\nRETURN.\nENDIF.\nWRITE 'hello'.", cnt: 0},
-  {abap: "IF foo = bar.\nRETURN. \" comment\nENDIF.\nWRITE 'hello'.", cnt: 0},
-  {abap: "SUBMIT zrest WITH s_messag IN sdfsd TO SAP-SPOOL SPOOL PARAMETERS ls_pr WITH" +
-    "OUT SPOOL DYNPRO VIA JOB gv_jobname NUMBER lv_jobcnt AND RETURN.\n" + "IF sy-subrc EQ 0.", cnt: 0},
-  {abap: "LEAVE TO LIST-PROCESSING AND RETURN TO SCREEN 0.\nWRITE moo.", cnt: 0},
+  {abap: `RETURN.
+            WRITE 'hello'.`, cnt: 1},
+
+  {abap: `IF foo = bar.
+            RETURN.
+          ENDIF.
+          WRITE 'hello'.`, cnt: 0},
+
+  {abap: `IF foo = bar.
+            RETURN. " comment
+          ENDIF.
+          WRITE 'hello'.`, cnt: 0},
+
+  {abap: `SUBMIT zrest
+            WITH s_messag IN sdfsd TO SAP-SPOOL SPOOL PARAMETERS ls_pr
+            WITH OUT SPOOL DYNPRO VIA JOB gv_jobname NUMBER lv_jobcnt AND RETURN.
+          IF sy-subrc EQ 0.
+          ENDIF.`, cnt: 0},
+
+  {abap: `LEAVE TO LIST-PROCESSING AND RETURN TO SCREEN 0.
+          WRITE moo.`, cnt: 0},
 ];
 
 testRule(tests, UnreachableCode);


### PR DESCRIPTION
This PR replaces concatenation using `\n" +` with multiline strings in test data to improve readability.

I think aligning like this 
```
const abap = `
string`;
```

adds a newline to the beginning of the string, but it is the most readable form and doesn't matter to the parser.