### PR TITLE
deploy schema only from the root repo

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: npm run schema
       run: npm run schema
     - name: deploy schema.abaplint.org
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.repository == 'abaplint/abaplint'
       env:
         MY_TOKEN: ${{ secrets.MY_TOKEN }}    
       run: |


### PR DESCRIPTION
... otherwise contributors are constantly receiving build failed notifications
