### PR TITLE
Add reason attribute to rule config

### DIFF
--- a/src/rules/_basic_rule_config.ts
+++ b/src/rules/_basic_rule_config.ts
@@ -3,4 +3,6 @@ export abstract class BasicRuleConfig {
   public enabled?: boolean = true;
   /** List of patterns to exclude */
   public exclude?: string[] = [];
+  /** An explanation for why the rule is enforced */
+  public reason?: string = "";
 }


### PR DESCRIPTION
Makes the config even more self-documenting: allows user-defined reasons for why the rules are there in the first place. You can link to clean abap, some in-house rules or just have a short description. It is also useful to put a comment if you're disabling a rule temporarily.