### PR TITLE
Playground - open links to syntax diagrams in new tab

### DIFF
--- a/web/playground/src/widgets/help.ts
+++ b/web/playground/src/widgets/help.ts
@@ -15,18 +15,18 @@ function escape(str: string) {
 }
 
 function linkToStatement(statement: any) {
-  return "<a href=\"https://syntax.abaplint.org/#/statement/" + statement.constructor.name + "\">" +
-    statement.constructor.name + "</a>";
+  return `<a href="https://syntax.abaplint.org/#/statement/${statement.constructor.name}"
+            target="_blank">${statement.constructor.name}</a>`;
 }
 
 function linkToStructure(structure: any) {
-  return "<a href=\"https://syntax.abaplint.org/#/structure/" + structure.constructor.name + "\">" +
-    structure.constructor.name + "</a>";
+  return `<a href="https://syntax.abaplint.org/#/structure/${structure.constructor.name}"
+             target="_blank">${structure.constructor.name}</a>`;
 }
 
 function linkToExpression(expression: any) {
-  return "<a href=\"https://syntax.abaplint.org/#/expression/" + expression.constructor.name + "\">" +
-    expression.constructor.name + "</a>";
+  return `<a href="https://syntax.abaplint.org/#/expression/${expression.constructor.name}"
+             target="_blank">${expression.constructor.name}</a>`;
 }
 
 function outputNodes(nodes: INode[]) {


### PR DESCRIPTION
Currently they do this:

![chrome_2019-09-27_09-44-18](https://user-images.githubusercontent.com/5097067/65752603-6b263000-e10d-11e9-9088-0a2e57ce1eba.png)

I don't think anyone would want to leave their work to go look at a diagram. This makes the links open in a new tab.