### PR TITLE
Rule: No Public Attributes, Refactoring + READ-ONLY

### DIFF
--- a/src/abap/types/class_attributes.ts
+++ b/src/abap/types/class_attributes.ts
@@ -25,12 +25,42 @@ export class Attributes {
     return this.static;
   }
 
+  public getStaticsByVisibility(visibility: Visibility): ClassAttribute[] {
+    const attributes: ClassAttribute[] = [];
+    for (const attr of this.static) {
+      if (attr.getVisibility() === visibility) {
+        attributes.push(attr);
+      }
+    }
+    return attributes;
+  }
+
   public getInstance(): ClassAttribute[] {
     return this.instance;
   }
 
+  public getInstancesByVisibility(visibility: Visibility): ClassAttribute[] {
+    const attributes: ClassAttribute[] = [];
+    for (const attr of this.instance) {
+      if (attr.getVisibility() === visibility) {
+        attributes.push(attr);
+      }
+    }
+    return attributes;
+  }
+
   public getConstants(): ClassConstant[] {
     return this.constants;
+  }
+
+  public getConstantsByVisibility(visibility: Visibility): ClassConstant[] {
+    const attributes: ClassConstant[] = [];
+    for (const attr of this.constants) {
+      if (attr.getVisibility() === visibility) {
+        attributes.push(attr);
+      }
+    }
+    return attributes;
   }
 
   public findByName(name: string): ClassAttribute | ClassConstant | undefined {

--- a/test/rules/no_public_attributes.ts
+++ b/test/rules/no_public_attributes.ts
@@ -1,0 +1,68 @@
+import {testRule} from "./_utils";
+import {NoPublicAttributes, NoPublicAttributesConf} from "../../src/rules";
+
+const tests = [
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+            DATA counter TYPE i.
+          ENDCLASS.`, cnt: 1},
+  // case with READ-ONLY in line break
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+            DATA counter TYPE i
+                READ-ONLY.
+            DATA abc TYPE i.
+          ENDCLASS.`, cnt: 2},
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+            DATA counter TYPE i READ-ONLY.
+            DATA abc TYPE i
+               READ-ONLY.
+            DATA foo type i.
+          ENDCLASS.`, cnt: 3},
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+            PROTECTED SECTION.
+            DATA counter TYPE i.
+            DATA abc TYPE i.
+          ENDCLASS.`, cnt: 0},
+];
+
+testRule(tests, NoPublicAttributes);
+
+const testsReadOnlyAllowed = [
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+                DATA counter TYPE i.
+          ENDCLASS.`, cnt: 1},
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+                DATA counter TYPE i
+                    READ-ONLY.
+                DATA abc TYPE i.
+            PROTECTED SECTION.
+                DATA foo TYPE i.
+            PRIVATE SECTION.
+                DATA oof TYPE i.
+          ENDCLASS.`, cnt: 1},
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+                DATA counter TYPE i READ-ONLY.
+                DATA abc TYPE i
+                    READ-ONLY.
+                DATA foo type i.
+          ENDCLASS.`, cnt: 1},
+  {abap: `CLASS lcl_abc DEFINITION.
+            PUBLIC SECTION.
+            PROTECTED SECTION.
+                DATA counter TYPE i.
+            PRIVATE SECTION.
+                DATA abc TYPE i.
+          ENDCLASS.`, cnt: 0},
+];
+
+
+const configAllowReadOnly = new NoPublicAttributesConf();
+configAllowReadOnly.allowReadOnly = true;
+
+testRule(testsReadOnlyAllowed, NoPublicAttributes, configAllowReadOnly);

--- a/test/rules/no_public_attributes.ts
+++ b/test/rules/no_public_attributes.ts
@@ -26,6 +26,10 @@ const tests = [
             DATA counter TYPE i.
             DATA abc TYPE i.
           ENDCLASS.`, cnt: 0},
+  {abap: `CLASS lcx_except DEFINITION INHERITING FROM cx_static_check.
+            PUBLIC SECTION.
+              DATA foo TYPE i.
+          ENDCLASS.`, cnt: 0},
 ];
 
 testRule(tests, NoPublicAttributes);
@@ -58,6 +62,10 @@ const testsReadOnlyAllowed = [
                 DATA counter TYPE i.
             PRIVATE SECTION.
                 DATA abc TYPE i.
+          ENDCLASS.`, cnt: 0},
+  {abap: `CLASS lcx_except DEFINITION INHERITING FROM cx_static_check.
+            PUBLIC SECTION.
+                DATA foo TYPE i.
           ENDCLASS.`, cnt: 0},
 ];
 


### PR DESCRIPTION
- adds config to allow public READ-ONLY attributes
- completely refactored the logic... I may have gone too far in a few places there, let me know if I should simplify it a bit (i.e. keep it all in the runParsed function)
- adds some helper functions for class_atributes 
- adds unit tests
- closes #345 