### PR TITLE
Method Length: Option to ignore Test Classes

### DIFF
--- a/src/rules/method_length.ts
+++ b/src/rules/method_length.ts
@@ -11,6 +11,9 @@ export class MethodLengthConf extends BasicRuleConfig {
   public statements: number = 100;
   /** Checks for empty methods. */
   public errorWhenEmpty: boolean = true;
+
+  /** Option to ignore test classes for this check.  */
+  public ignoreTestClasses: boolean = false;
 }
 
 enum IssueType {
@@ -51,8 +54,10 @@ export class MethodLength implements IRule {
   public run(obj: IObject, _reg: Registry): Issue[] {
     const issues: Issue[] = [];
     const stats = MethodLengthStats.run(obj);
-
     for (const s of stats) {
+      if (this.conf.ignoreTestClasses && s.file.getFilename().includes(".testclasses.")) {
+        continue;
+      }
       if (s.count === 0 && this.conf.errorWhenEmpty === true) {
         const issue = Issue.atPosition(s.file, s.pos, this.getDescription(IssueType.EmptyMethod, "0"), this.getKey());
         issues.push(issue);

--- a/src/rules/method_length.ts
+++ b/src/rules/method_length.ts
@@ -55,7 +55,8 @@ export class MethodLength implements IRule {
     const issues: Issue[] = [];
     const stats = MethodLengthStats.run(obj);
     for (const s of stats) {
-      if (this.conf.ignoreTestClasses && s.file.getFilename().includes(".testclasses.")) {
+      if ((this.conf.ignoreTestClasses === true)
+        && s.file.getFilename().includes(".testclasses.")) {
         continue;
       }
       if (s.count === 0 && this.conf.errorWhenEmpty === true) {

--- a/test/rules/method_length.ts
+++ b/test/rules/method_length.ts
@@ -1,7 +1,135 @@
 import {MethodLength, MethodLengthConf} from "../../src/rules/method_length";
 import {testRule} from "./_utils";
+import {Registry} from "../../src/registry";
+import {MemoryFile} from "../../src/files";
+import {expect} from "chai";
 
-const tests = [
+function testRulesWithFile(tests: any): void {
+  describe("test files for method length", function () {
+    tests.forEach((test: any) => {
+      const reg = new Registry();
+      reg.addFile(new MemoryFile(test.filename, test.abap)).parse();
+
+      const rule = new MethodLength();
+      rule.setConfig(test.conf);
+
+      const issues = rule.run(reg.getObjects()[0], reg);
+      it(test.description, () => {
+        expect(issues.length).to.equals(test.issueLength);
+      });
+    });
+  });
+}
+
+const confIgnoreTestClasses = new MethodLengthConf();
+confIgnoreTestClasses.ignoreTestClasses = true;
+confIgnoreTestClasses.statements = 3;
+
+const confCheckTestClasses = new MethodLengthConf();
+confCheckTestClasses.ignoreTestClasses = false;
+confCheckTestClasses.statements = 3;
+
+const abapTestClassOverLength = `
+  CLASS ltcl_foo definition final for testing.
+    PUBLIC SECTION.
+      METHODS foo.
+  ENDCLASS.
+  CLASS ltcl_foo IMPLEMENTATION.
+    METHOD foo.
+      WRITE '1''.
+      WRITE '2'.
+      WRITE '3'.
+      WRITE '4'.
+    ENDMETHOD.
+  ENDCLASS.`;
+
+const abapTestClassValidLength = `
+  CLASS ltcl_foo definition final for testing.
+    PUBLIC SECTION.
+      METHODS foo.
+  ENDCLASS.
+  CLASS ltcl_foo IMPLEMENTATION.
+    METHOD foo.
+      WRITE '1''.
+      WRITE '2'.
+      WRITE '3'.
+    ENDMETHOD.
+  ENDCLASS.`;
+
+const abapClassOverLength = `
+  CLASS zcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+  ENDCLASS.
+  CLASS zcl_foo IMPLEMENTATION.
+    METHOD foo.
+      WRITE '1''.
+      WRITE '2'.
+      WRITE '3'.
+      WRITE '4'.
+    ENDMETHOD.
+  ENDCLASS.`;
+
+const abapClassValidLength = `
+  CLASS zcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+  ENDCLASS.
+  CLASS zcl_foo IMPLEMENTATION.
+    METHOD foo.
+      WRITE '1''.
+      WRITE '2'.
+      WRITE '3'.
+    ENDMETHOD.
+  ENDCLASS.`;
+
+const testClassTests = [
+  { abap: abapTestClassOverLength,
+    description: "testclass, ignore, over length",
+    conf: confIgnoreTestClasses,
+    filename: `zcl_foo.clas.testclasses.abap`,
+    issueLength: 0},
+
+  { abap: abapTestClassOverLength,
+    description: "testclass, check, over length",
+    conf: confCheckTestClasses,
+    filename: `zcl_foo.clas.testclasses.abap`,
+    issueLength: 1},
+
+  { abap: abapTestClassValidLength,
+    description: "testclass, check, valid length",
+    conf: confCheckTestClasses,
+    filename: `zcl_foo.clas.testclasses.abap`,
+    issueLength: 0},
+
+  { abap: abapTestClassValidLength,
+    description: "testclass, ignore, valid length",
+    conf: confIgnoreTestClasses,
+    filename: `zcl_foo.clas.testclasses.abap`,
+    issueLength: 0},
+
+  { abap: abapClassOverLength,
+    description: "class, ignore, over length",
+    conf: confIgnoreTestClasses,
+    filename: `zcl_foo.clas.abap`,
+    issueLength: 1},
+
+  { abap: abapClassOverLength,
+    description: "class, check, over length",
+    conf: confCheckTestClasses,
+    filename: `zcl_foo.clas.abap`,
+    issueLength: 1},
+
+  { abap: abapClassValidLength,
+    description: "class, check, valid length",
+    conf: confCheckTestClasses,
+    filename: `zcl_foo.clas.abap`,
+    issueLength: 0},
+];
+
+testRulesWithFile(testClassTests);
+
+const lengthTests = [
   {abap: "parser error", cnt: 0},
   {abap: "WRITE: / 'abc'.", cnt: 0},
   {abap: "METHOD foobar. ENDMETHOD.", cnt: 1},
@@ -160,7 +288,7 @@ const tests = [
   ENDMETHOD.`, cnt: 1},
 ];
 
-testRule(tests, MethodLength);
+testRule(lengthTests, MethodLength);
 
 
 const emptyMethodTests = [


### PR DESCRIPTION
- add option to ignore test classes for method length checks
- if enabled, ignores  `.testclasses.` files
- add new test cases
- closes #631 
