### PR TITLE
Configurable keyword case + pretty printer

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -1226,10 +1226,10 @@
                 }
               ]
             },
-            "keywords_upper": {
+            "keyword_case": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/KeywordsUpperConf"
+                  "$ref": "#/definitions/KeywordCaseConf"
                 },
                 {
                   "type": "boolean"
@@ -1836,9 +1836,9 @@
       },
       "type": "object"
     },
-    "KeywordsUpperConf": {
+    "KeywordCaseConf": {
       "additionalProperties": false,
-      "description": "Detects keywords which are not uppercased, non-keywords must be lower case.",
+      "description": "Checks that keywords have the same case. Non-keywords must be lower case.",
       "properties": {
         "enabled": {
           "description": "Is the rule enabled?",
@@ -1870,9 +1870,13 @@
         "reason": {
           "description": "An explanation for why the rule is enforced",
           "type": "string"
+        },
+        "style": {
+          "$ref": "#/definitions/KeywordCaseStyle"
         }
       },
       "required": [
+        "style",
         "ignoreExceptions",
         "ignoreLowerClassImplmentationStatement",
         "ignoreGlobalClassDefinition",
@@ -1880,6 +1884,13 @@
         "ignoreFunctionModuleName"
       ],
       "type": "object"
+    },
+    "KeywordCaseStyle": {
+      "enum": [
+        "upper",
+        "lower"
+      ],
+      "type": "string"
     },
     "LineLengthConf": {
       "additionalProperties": false,

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -37,7 +37,7 @@ import {ImplementMethodsConf} from "../src/rules/syntax/implement_methods";
 import {InStatementIndentationConf} from "../src/rules/whitespace/in_statement_indentation";
 import {IndentationConf} from "../src/rules/whitespace/indentation";
 import {InlineDataOldVersionsConf} from "../src/rules/syntax/inline_data_old_versions";
-import {KeywordsUpperConf} from "../src/rules/keywords_upper";
+import {KeywordCaseConf} from "../src/rules/keyword_case";
 import {LineLengthConf} from "../src/rules/line_length";
 import {LineOnlyPuncConf} from "../src/rules/line_only_punc";
 import {LocalClassNamingConf} from "../src/rules/naming/local_class_naming";
@@ -117,7 +117,7 @@ export interface IConfig {
     "in_statement_indentation"?: InStatementIndentationConf | boolean,
     "indentation"?: IndentationConf | boolean,
     "inline_data_old_versions"?: InlineDataOldVersionsConf | boolean,
-    "keywords_upper"?: KeywordsUpperConf | boolean,
+    "keywords_upper"?: KeywordCaseConf | boolean,
     "line_length"?: LineLengthConf | boolean,
     "line_only_punc"?: LineOnlyPuncConf | boolean,
     "local_class_naming"?: LocalClassNamingConf | boolean,

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -117,7 +117,7 @@ export interface IConfig {
     "in_statement_indentation"?: InStatementIndentationConf | boolean,
     "indentation"?: IndentationConf | boolean,
     "inline_data_old_versions"?: InlineDataOldVersionsConf | boolean,
-    "keywords_upper"?: KeywordCaseConf | boolean,
+    "keyword_case"?: KeywordCaseConf | boolean,
     "line_length"?: LineLengthConf | boolean,
     "line_only_punc"?: LineOnlyPuncConf | boolean,
     "local_class_naming"?: LocalClassNamingConf | boolean,

--- a/src/pretty_printer/fix_keyword_case.ts
+++ b/src/pretty_printer/fix_keyword_case.ts
@@ -1,23 +1,30 @@
 import {StatementNode, ExpressionNode, TokenNodeRegex, TokenNode} from "../abap/nodes";
 import {Identifier} from "../abap/tokens";
 import {Position} from "../position";
+import {Config} from "..";
+import {KeywordCase, KeywordCaseStyle} from "../rules/keyword_case";
 
 
-export class UppercaseKeywords {
+export class FixKeywordCase {
   private fileContents: string;
-  public constructor(fileContents: string) {
+  private readonly config: Config;
+  private readonly keywordCase: KeywordCase;
+  public constructor(fileContents: string, config: Config) {
+    this.keywordCase = new KeywordCase();
+    this.keywordCase.setConfig(config.readByRule(this.keywordCase.getKey()));
     this.fileContents = fileContents;
+    this.config = config;
   }
 
-  public execute(s: StatementNode | ExpressionNode): string {
-    for (const child of s.getChildren()) {
+  public execute(statement: StatementNode | ExpressionNode): string {
+    for (const child of statement.getChildren()) {
       if (child instanceof TokenNodeRegex) {
         continue;
       } else if (child instanceof TokenNode) {
         const token = child.get();
         const str = token.getStr();
-        if (str !== str.toUpperCase() && token instanceof Identifier) {
-          this.replaceString(token.getStart(), str.toUpperCase());
+        if (this.keywordCase.violatesRule(str) && token instanceof Identifier) {
+          this.replaceString(token.getStart(), this.formatKeyword(str));
         }
       } else if (child instanceof ExpressionNode) {
         this.execute(child);
@@ -27,6 +34,12 @@ export class UppercaseKeywords {
     }
 
     return this.fileContents;
+  }
+
+  private formatKeyword(keyword: string): string {
+    const rule = this.keywordCase.getKey();
+    const style: KeywordCaseStyle = this.config.readByRule(rule)["style"];
+    return style === "lower" ? keyword.toLowerCase() : keyword.toUpperCase();
   }
 
   private replaceString(pos: Position, str: string) {

--- a/src/pretty_printer/fix_keyword_case.ts
+++ b/src/pretty_printer/fix_keyword_case.ts
@@ -39,7 +39,7 @@ export class FixKeywordCase {
   private formatKeyword(keyword: string): string {
     const rule = this.keywordCase.getKey();
     const style: KeywordCaseStyle = this.config.readByRule(rule)["style"];
-    return style === "lower" ? keyword.toLowerCase() : keyword.toUpperCase();
+    return style === KeywordCaseStyle.Lower ? keyword.toLowerCase() : keyword.toUpperCase();
   }
 
   private replaceString(pos: Position, str: string) {

--- a/src/pretty_printer/pretty_printer.ts
+++ b/src/pretty_printer/pretty_printer.ts
@@ -2,7 +2,7 @@
 import {Unknown, MacroContent, MacroCall, Comment} from "../abap/statements/_statement";
 import {ABAPFile} from "../files";
 import {Config} from "..";
-import {UppercaseKeywords} from "./uppercase_keywords";
+import {FixKeywordCase} from "./fix_keyword_case";
 import {Indent as Indent} from "./indent";
 import {IIndentationOptions} from "./indentation_options";
 import {RemoveSequentialBlanks} from "./remove_sequential_blanks";
@@ -31,7 +31,7 @@ export class PrettyPrinter {
       }
 
       // note that no positions are changed during a upperCaseKeys operation
-      const upperCaseKeywords = new UppercaseKeywords(this.result);
+      const upperCaseKeywords = new FixKeywordCase(this.result, this.config);
       this.result = upperCaseKeywords.execute(statement);
     }
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -22,7 +22,7 @@ export * from "./form_tables_obsolete";
 export * from "./functional_writing";
 export * from "./identical_form_names";
 export * from "./if_in_if";
-export * from "./keywords_upper";
+export * from "./keyword_case";
 export * from "./line_length";
 export * from "./line_only_punc";
 export * from "./local_testclass_location";

--- a/src/rules/keyword_case.ts
+++ b/src/rules/keyword_case.ts
@@ -12,8 +12,11 @@ import * as Statements from "../abap/statements";
 import * as Expressions from "../abap/expressions";
 import {Token} from "../abap/tokens/_token";
 
+export type KeywordCaseStyle = "upper" | "lower";
+
 /** Detects keywords which are not uppercased, non-keywords must be lower case. */
-export class KeywordsUpperConf extends BasicRuleConfig {
+export class KeywordCaseConf extends BasicRuleConfig {
+  public style: KeywordCaseStyle = "lower";
   /** Ignore global exception classes */
   public ignoreExceptions: boolean = true;
   public ignoreLowerClassImplmentationStatement: boolean = true;
@@ -22,19 +25,19 @@ export class KeywordsUpperConf extends BasicRuleConfig {
   public ignoreFunctionModuleName: boolean = false;
 }
 
-export class KeywordsUpper extends ABAPRule {
+export class KeywordCase extends ABAPRule {
 
-  private conf = new KeywordsUpperConf();
+  private conf = new KeywordCaseConf();
 
   public getKey(): string {
-    return "keywords_upper";
+    return "keyword_case";
   }
 
   private getDescription(tokenValue: string, keyword: boolean): string {
     if (keyword === true) {
-      return "Keyword should be upper case: \"" + tokenValue + "\"";
+      return `Keyword should be ${this.conf.style} case: "${tokenValue}"`;
     } else {
-      return "Identifiers should be lower case: \"" + tokenValue + "\"";
+      return `Identifiers should be lower case: "${tokenValue}"`;
     }
   }
 
@@ -42,7 +45,7 @@ export class KeywordsUpper extends ABAPRule {
     return this.conf;
   }
 
-  public setConfig(conf: KeywordsUpperConf) {
+  public setConfig(conf: KeywordCaseConf) {
     this.conf = conf;
   }
 
@@ -59,15 +62,15 @@ export class KeywordsUpper extends ABAPRule {
 
     for (const statement of file.getStatements()) {
       if (statement.get() instanceof Unknown
-          || statement.get() instanceof MacroContent
-          || statement.get() instanceof MacroCall
-          || statement.get() instanceof Comment) {
+        || statement.get() instanceof MacroContent
+        || statement.get() instanceof MacroCall
+        || statement.get() instanceof Comment) {
         continue;
       }
 
       if (this.conf.ignoreGlobalClassDefinition) {
         if (statement.get() instanceof Statements.ClassDefinition
-            && statement.findFirstExpression(Expressions.Global)) {
+          && statement.findFirstExpression(Expressions.Global)) {
           skip = true;
           continue;
         } else if (skip === true && statement.get() instanceof Statements.EndClass) {
@@ -80,7 +83,7 @@ export class KeywordsUpper extends ABAPRule {
 
       if (this.conf.ignoreGlobalInterface) {
         if (statement.get() instanceof Statements.Interface
-            && statement.findFirstExpression(Expressions.Global)) {
+          && statement.findFirstExpression(Expressions.Global)) {
           skip = true;
           continue;
         } else if (skip === true && statement.get() instanceof Statements.EndInterface) {
@@ -107,7 +110,7 @@ export class KeywordsUpper extends ABAPRule {
     for (const child of s.getChildren()) {
       if (child instanceof TokenNodeRegex) {
         if (this.conf.ignoreLowerClassImplmentationStatement
-            && parent instanceof Statements.ClassImplementation) {
+          && parent instanceof Statements.ClassImplementation) {
           continue;
         }
         const str = child.get().getStr();
@@ -120,7 +123,7 @@ export class KeywordsUpper extends ABAPRule {
           continue;
         }
         if (this.conf.ignoreFunctionModuleName === true
-            && parent instanceof Statements.FunctionModule && str.toUpperCase() !== "FUNCTION") {
+          && parent instanceof Statements.FunctionModule && str.toUpperCase() !== "FUNCTION") {
           continue;
         }
         if (parent instanceof Statements.ModifyInternal && str.toUpperCase() === "SCREEN") {
@@ -135,7 +138,7 @@ export class KeywordsUpper extends ABAPRule {
         }
       } else if (child instanceof TokenNode) {
         const str = child.get().getStr();
-        if (str !== str.toUpperCase() && child.get() instanceof Identifier) {
+        if (this.violatesRule(str) && child.get() instanceof Identifier) {
           return {token: child.get(), keyword: true};
         }
       } else if (child instanceof ExpressionNode) {
@@ -149,6 +152,18 @@ export class KeywordsUpper extends ABAPRule {
     }
 
     return {token: undefined, keyword: false};
+  }
+
+  private violatesRule(keyword: string): boolean {
+    if (this.conf.style === "lower") {
+      return keyword !== keyword.toLowerCase();
+    }
+
+    if (this.conf.style === "upper") {
+      return keyword !== keyword.toUpperCase();
+    }
+
+    return false;
   }
 
 }

--- a/src/rules/keyword_case.ts
+++ b/src/rules/keyword_case.ts
@@ -16,7 +16,7 @@ export type KeywordCaseStyle = "upper" | "lower";
 
 /** Detects keywords which are not uppercased, non-keywords must be lower case. */
 export class KeywordCaseConf extends BasicRuleConfig {
-  public style: KeywordCaseStyle = "lower";
+  public style: KeywordCaseStyle = "upper";
   /** Ignore global exception classes */
   public ignoreExceptions: boolean = true;
   public ignoreLowerClassImplmentationStatement: boolean = true;
@@ -154,7 +154,7 @@ export class KeywordCase extends ABAPRule {
     return {token: undefined, keyword: false};
   }
 
-  private violatesRule(keyword: string): boolean {
+  public violatesRule(keyword: string): boolean {
     if (this.conf.style === "lower") {
       return keyword !== keyword.toLowerCase();
     }

--- a/src/rules/keyword_case.ts
+++ b/src/rules/keyword_case.ts
@@ -14,7 +14,7 @@ import {Token} from "../abap/tokens/_token";
 
 export type KeywordCaseStyle = "upper" | "lower";
 
-/** Detects keywords which are not uppercased, non-keywords must be lower case. */
+/** Checks that keywords have the same case. Non-keywords must be lower case. */
 export class KeywordCaseConf extends BasicRuleConfig {
   public style: KeywordCaseStyle = "upper";
   /** Ignore global exception classes */

--- a/src/rules/keyword_case.ts
+++ b/src/rules/keyword_case.ts
@@ -12,11 +12,15 @@ import * as Statements from "../abap/statements";
 import * as Expressions from "../abap/expressions";
 import {Token} from "../abap/tokens/_token";
 
-export type KeywordCaseStyle = "upper" | "lower";
+export enum KeywordCaseStyle {
+  Upper = "upper",
+  Lower = "lower",
+}
+
 
 /** Checks that keywords have the same case. Non-keywords must be lower case. */
 export class KeywordCaseConf extends BasicRuleConfig {
-  public style: KeywordCaseStyle = "upper";
+  public style: KeywordCaseStyle = KeywordCaseStyle.Upper;
   /** Ignore global exception classes */
   public ignoreExceptions: boolean = true;
   public ignoreLowerClassImplmentationStatement: boolean = true;
@@ -155,11 +159,11 @@ export class KeywordCase extends ABAPRule {
   }
 
   public violatesRule(keyword: string): boolean {
-    if (this.conf.style === "lower") {
+    if (this.conf.style === KeywordCaseStyle.Lower) {
       return keyword !== keyword.toLowerCase();
     }
 
-    if (this.conf.style === "upper") {
+    if (this.conf.style === KeywordCaseStyle.Upper) {
       return keyword !== keyword.toUpperCase();
     }
 

--- a/test/abap/pretty_printer.ts
+++ b/test/abap/pretty_printer.ts
@@ -3,7 +3,7 @@ import {PrettyPrinter} from "../../src/pretty_printer/pretty_printer";
 import {MemoryFile} from "../../src/files";
 import {Registry} from "../../src/registry";
 import {Indent} from "../../src/pretty_printer/indent";
-import {KeywordCaseConf} from "../../src/rules";
+import {KeywordCaseConf, KeywordCaseStyle} from "../../src/rules";
 
 const testTitle = (text: string): string => {return text.split("\n")[0]; };
 
@@ -124,10 +124,10 @@ describe("Remove sequential blanks", () => {
 
 describe("Fix keyword case", () => {
   const lowerCaseConfig = new KeywordCaseConf();
-  lowerCaseConfig.style = "lower";
+  lowerCaseConfig.style = KeywordCaseStyle.Lower;
 
   const upperCaseConfig = new KeywordCaseConf();
-  upperCaseConfig.style = "upper";
+  upperCaseConfig.style = KeywordCaseStyle.Upper;
 
   const tests = [
     {

--- a/test/rules/_utils.ts
+++ b/test/rules/_utils.ts
@@ -3,12 +3,13 @@ import {Registry} from "../../src/registry";
 import {MemoryFile} from "../../src/files/memory_file";
 import {IRule} from "../../src/rules/_irule";
 
-export function testRule(tests: any, rule: new () => IRule, config?: any) {
+export function testRule(tests: any, rule: new () => IRule, config?: any, testTitle?: string) {
   const nrule = new rule();
   if (config) {
     nrule.setConfig(config);
   }
-  describe("test " + nrule.getKey() + " rule", function () {
+  testTitle = testTitle || `test ${nrule.getKey()} rule`;
+  describe(testTitle, function () {
     // note that timeout() only works inside function()
     this.timeout(200); // tslint:disable-line
     tests.forEach((test: any) => {

--- a/test/rules/keyword_case.ts
+++ b/test/rules/keyword_case.ts
@@ -1,4 +1,4 @@
-import {KeywordsUpper, KeywordsUpperConf} from "../../src/rules/keywords_upper";
+import {KeywordCase, KeywordCaseConf} from "../../src/rules/keyword_case";
 import {testRule} from "./_utils";
 
 const tests = [
@@ -31,7 +31,7 @@ const tests = [
   {abap: "IF foo = bar and moo = boo.", cnt: 1},
 ];
 
-testRule(tests, KeywordsUpper);
+testRule(tests, KeywordCase);
 
 // ************************
 
@@ -41,11 +41,11 @@ const tests2 = [
   {abap: "class ycl_something definition public final.\nendclass.\nwrite foo.", cnt: 1},
 ];
 
-const config2 = new KeywordsUpperConf();
+const config2 = new KeywordCaseConf();
 config2.ignoreGlobalClassDefinition = true;
 config2.ignoreGlobalInterface = true;
 
-testRule(tests2, KeywordsUpper, config2);
+testRule(tests2, KeywordCase, config2);
 
 // ************************
 
@@ -56,7 +56,42 @@ const tests3 = [
   {abap: "fUNCTION zfoobar.\n", cnt: 1},
 ];
 
-const config3 = new KeywordsUpperConf();
+const config3 = new KeywordCaseConf();
 config3.ignoreFunctionModuleName = true;
 
-testRule(tests3, KeywordsUpper, config3);
+testRule(tests3, KeywordCase, config3);
+
+const config4 = new KeywordCaseConf();
+config4.style = "lower";
+
+const tests4 = [
+  {abap: "IF a = b.", cnt: 1},
+  {abap: "foo = |sdf|.", cnt: 0},
+  {abap: "foo = boolc( 1 = 2 ).", cnt: 0},
+  {abap: "IF a = b.", cnt: 1},
+  {abap: "IF A = b.", cnt: 1}, // "A" should be lower case
+  {abap: "CLASS ZCL_ABAPGIT_ZLIB_STREAM IMPLEMENTATION.", cnt: 1}, // txn SE80 upper cases the keyword when saving
+  {abap: `call function 'ZMOOBOO'
+  exporting
+    iv_fild     = lv_value
+  exceptions
+    invalid_boo = 1
+    others      = 2.`, cnt: 0},
+  {abap: "LOOP AT SCREEN.", cnt: 1},
+  {abap: "MODIFY SCREEN.",  cnt: 1},
+  {abap: "field-symbols <lv_dst> type ANY.", cnt: 0}, // todo, "ANY" should be lower case
+  {abap: "field-symbols <ls_auth> like line of gt_auth.", cnt: 0}, // todo
+  {abap: "select single ccnocliind from t000 into lv_ind where mandt = sy-mandt.", cnt: 0},
+  {abap: "sort mt_items by txt ascending as text.", cnt: 0},
+  {abap: "delete adjacent duplicates from mt_requirements comparing all fields.", cnt: 0},
+  {abap: "at first.", cnt: 0},
+  {abap: "select devclass from tdevc into table lt_list where parentcl = mv_package order by primary key.", cnt: 0},
+  {abap: "select distinct sprsl as langu into table lt_i18n_langs from t100t.", cnt: 0},
+  {abap: "selection-screen begin of block b1 with frame title text-001.", cnt: 0},
+  {abap: "function ZFOOBAR.\n", cnt: 1},
+  {abap: "select foo up to @bar rows into corresponding fields of table @boo from loo.", cnt: 0},
+  {abap: "sort rt_list by repo-name as text ascending.", cnt: 0},
+];
+
+testRule(tests4, KeywordCase, config4);
+

--- a/test/rules/keyword_case.ts
+++ b/test/rules/keyword_case.ts
@@ -1,4 +1,4 @@
-import {KeywordCase, KeywordCaseConf} from "../../src/rules/keyword_case";
+import {KeywordCase, KeywordCaseConf, KeywordCaseStyle} from "../../src/rules/keyword_case";
 import {testRule} from "./_utils";
 
 const tests = [
@@ -62,7 +62,7 @@ config3.ignoreFunctionModuleName = true;
 testRule(tests3, KeywordCase, config3);
 
 const config4 = new KeywordCaseConf();
-config4.style = "lower";
+config4.style = KeywordCaseStyle.Lower;
 
 const tests4 = [
   {abap: "IF a = b.", cnt: 1},


### PR DESCRIPTION
@sbcgua you should like this
- `keywords_upper` renamed to `keyword_case` which has a `style: upper | lower` property
- pretty printer will uppercase or lowercase depending on the style