### PR TITLE
New Rule: Newline between methods

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -1398,6 +1398,16 @@
                 }
               ]
             },
+            "newline_between_methods": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NewlineBetweenMethodsConf"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
             "no_public_attributes": {
               "anyOf": [
                 {
@@ -2355,6 +2365,27 @@
       "required": [
         "depth"
       ],
+      "type": "object"
+    },
+    "NewlineBetweenMethodsConf": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Is the rule enabled?",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "List of file regex patterns to exclude",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "description": "An explanation for why the rule is enforced",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "NoPublicAttributesConf": {

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -52,6 +52,7 @@ import {MethodParameterNamesConf} from "../src/rules/naming/method_parameter_nam
 import {MixReturningConf} from "../src/rules/mix_returning";
 import {MSAGConsistencyConf} from "../src/rules/msag_consistency";
 import {NestingConf} from "../src/rules/nesting";
+import {NewlineBetweenMethodsConf} from "../src/rules/whitespace/newline_between_methods";
 import {NoPublicAttributesConf} from "../src/rules/no_public_attributes";
 import {ObjectNamingConf} from "../src/rules/naming/object_naming";
 import {ObsoleteStatementConf} from "../src/rules/obsolete_statement";
@@ -133,6 +134,7 @@ export interface IConfig {
     "mix_returning"?: MixReturningConf | boolean,
     "msag_consistency"?: MSAGConsistencyConf | boolean,
     "nesting"?: NestingConf | boolean,
+    "newline_between_methods"?: NewlineBetweenMethodsConf | boolean,
     "no_public_attributes"?: NoPublicAttributesConf | boolean,
     "object_naming"?: ObjectNamingConf | boolean,
     "obsolete_statement"?: ObsoleteStatementConf | boolean,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -68,6 +68,7 @@ export * from "./whitespace/contains_tab";
 export * from "./whitespace/double_space";
 export * from "./whitespace/in_statement_indentation";
 export * from "./whitespace/indentation";
+export * from "./whitespace/newline_between_methods";
 export * from "./whitespace/sequential_blank";
 export * from "./whitespace/space_before_colon";
 export * from "./whitespace/space_before_dot";

--- a/src/rules/whitespace/newline_between_methods.ts
+++ b/src/rules/whitespace/newline_between_methods.ts
@@ -1,0 +1,47 @@
+import {Issue} from "../../issue";
+import {BasicRuleConfig} from "../_basic_rule_config";
+import {ABAPRule} from "../_abap_rule";
+import {ABAPFile} from "../../files";
+import {SequentialBlank} from "./sequential_blank";
+import * as Statements from "../../abap/statements";
+
+export class NewlineBetweenMethodsConf extends BasicRuleConfig {}
+
+export class NewlineBetweenMethods extends ABAPRule {
+  private conf = new NewlineBetweenMethodsConf();
+
+  public getKey(): string {
+    return "newline_between_methods";
+  }
+
+  private getDescription(): string {
+    return `A single newline is required in between methods.`;
+  }
+
+  public getConfig() {
+    return this.conf;
+  }
+
+  public setConfig(conf: NewlineBetweenMethodsConf) {
+    this.conf = conf;
+  }
+
+  public runParsed(file: ABAPFile): Issue[] {
+    const issues: Issue[] = [];
+    const rows = file.getRawRows();
+    for (const statement of file.getStatements()) {
+      const nextRow = statement.getStart().getRow();
+      if (!(statement.get() instanceof Statements.EndMethod)
+          || (rows[nextRow].includes("ENDCLASS.")
+          || (SequentialBlank.isBlankOrWhitespace(rows[nextRow]) && !SequentialBlank.isBlankOrWhitespace(rows[nextRow + 1])))) {
+        continue;
+      }
+      issues.push(Issue.atStatement(
+        file,
+        statement,
+        this.getDescription(),
+        this.getKey()));
+    }
+    return issues;
+  }
+}

--- a/test/rules/whitespace/newline_between_methods.ts
+++ b/test/rules/whitespace/newline_between_methods.ts
@@ -1,0 +1,103 @@
+import {NewlineBetweenMethods} from "../../../src/rules/whitespace/newline_between_methods";
+import {testRule} from "../_utils";
+
+const tests = [
+  {
+    abap: `
+    CLASS lcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+      METHODS abc.
+    ENDCLASS.
+    CLASS lcl_foo IMPLEMENTATION.
+      METHOD foo.
+        WRITE '4'.
+      ENDMETHOD.
+
+
+      METHOD abc.
+        WRITE '1'.
+      ENDMETHOD.
+    ENDCLASS.`,
+    cnt: 1,
+  },
+  {
+    abap: `
+    CLASS lcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+      METHODS abc.
+    ENDCLASS.
+    CLASS lcl_foo IMPLEMENTATION.
+      METHOD foo.
+        WRITE '4'.
+      ENDMETHOD.
+      METHOD abc.
+        WRITE '1'.
+      ENDMETHOD.
+    ENDCLASS.`,
+    cnt: 1,
+  },
+  {
+    abap: `
+    CLASS lcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+      METHODS abc.
+    ENDCLASS.
+    CLASS lcl_foo IMPLEMENTATION.
+      METHOD foo.
+        WRITE '4'.
+      ENDMETHOD.
+
+      METHOD abc.
+        WRITE '1'.
+      ENDMETHOD.
+    ENDCLASS.`,
+    cnt: 0,
+  },
+  {
+    abap: `
+    CLASS lcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+      METHODS abc.
+    ENDCLASS.
+    CLASS lcl_foo IMPLEMENTATION.
+      METHOD foo.
+        WRITE '4'.
+      ENDMETHOD.
+
+      METHOD abc.
+        WRITE '1'.
+      ENDMETHOD.
+
+    ENDCLASS.`,
+    cnt: 0,
+  },
+  {
+    abap: `
+    CLASS lcl_foo DEFINITION CREATE PUBLIC.
+    PUBLIC SECTION.
+      METHODS foo.
+      METHODS abc.
+      METHODS bar.
+    ENDCLASS.
+    CLASS lcl_foo IMPLEMENTATION.
+      METHOD foo.
+        WRITE '4'.
+      ENDMETHOD.
+
+
+      METHOD abc.
+        WRITE '1'.
+      ENDMETHOD.
+      METHOD bar.
+        WRITE '2'.
+      ENDMETHOD.
+    ENDCLASS.`,
+    cnt: 2,
+  },
+];
+
+testRule(tests, NewlineBetweenMethods);


### PR DESCRIPTION
- checks for a single new line after each `ENDMETHOD`
- exception: `ENDMETHOD` before `ENDCLASS`, newline optional in this case (multiple newlines will be marked though)
- closes #164 