### PR TITLE
New Rule: Comment Checks

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -225,6 +225,35 @@
       },
       "type": "object"
     },
+    "CheckCommentsConf": {
+      "additionalProperties": false,
+      "description": "Various checks for comment usage.",
+      "properties": {
+        "allowEndOfLine": {
+          "description": "Allows the use of end-of-line comments.",
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Is the rule enabled?",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "List of file regex patterns to exclude",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "description": "An explanation for why the rule is enforced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowEndOfLine"
+      ],
+      "type": "object"
+    },
     "CheckDDICConf": {
       "additionalProperties": false,
       "description": "Checks the types of DDIC objects can be resolved, the namespace of the development/errors can be configured in \"errorNamespace\"",
@@ -952,6 +981,16 @@
               "anyOf": [
                 {
                   "$ref": "#/definitions/CheckAbstractConf"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "check_comments": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CheckCommentsConf"
                 },
                 {
                   "type": "boolean"

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -8,6 +8,7 @@ import {BeginEndNamesConf} from "../src/rules/syntax/begin_end_names";
 import {BreakpointConf} from "../src/rules/breakpoint";
 import {ChainMainlyDeclarationsConf} from "../src/rules/chain_mainly_declarations";
 import {CheckAbstractConf} from "../src/rules/check_abstract";
+import {CheckCommentsConf} from "../src/rules/check_comments";
 import {CheckDDICConf} from "../src/rules/syntax/check_ddic";
 import {CheckIncludeConf} from "../src/rules/syntax/check_include";
 import {CheckNoHandlerPragmaConf} from "../src/rules/check_no_handler_pragma";
@@ -90,6 +91,7 @@ export interface IConfig {
     "breakpoint"?: BreakpointConf | boolean,
     "chain_mainly_declarations"?: ChainMainlyDeclarationsConf | boolean,
     "check_abstract"?: CheckAbstractConf | boolean,
+    "check_comments"?: CheckCommentsConf | boolean,
     "check_ddic"?: CheckDDICConf | boolean,
     "check_include"?: CheckIncludeConf | boolean,
     "check_no_handler_pragma"?: CheckNoHandlerPragmaConf | boolean,

--- a/src/rules/check_comments.ts
+++ b/src/rules/check_comments.ts
@@ -1,5 +1,4 @@
 import {Issue} from "../issue";
-// import * as Statements from "../abap/statements";
 import {Comment} from "../abap/statements/_statement";
 import {BasicRuleConfig} from "./_basic_rule_config";
 import {ABAPRule} from "./_abap_rule";

--- a/src/rules/check_comments.ts
+++ b/src/rules/check_comments.ts
@@ -1,0 +1,66 @@
+import {Issue} from "../issue";
+// import * as Statements from "../abap/statements";
+import {Comment} from "../abap/statements/_statement";
+import {BasicRuleConfig} from "./_basic_rule_config";
+import {ABAPRule} from "./_abap_rule";
+import {ABAPFile} from "../files";
+
+/** Various checks for comment usage. */
+export class CheckCommentsConf extends BasicRuleConfig {
+  /** Allows the use of end-of-line comments. */
+  public allowEndOfLine: boolean = false;
+}
+
+enum IssueType {
+  EndOfLine,
+}
+export class CheckComments extends ABAPRule {
+  private conf = new CheckCommentsConf();
+
+  public getKey(): string {
+    return "check_comments";
+  }
+
+  private getDescription(issueType: IssueType): string {
+    switch (issueType) {
+      case IssueType.EndOfLine: return `Do not use end of line comments - move comment to previous row instead.`;
+      default: return "";
+    }
+  }
+
+  public getConfig() {
+    return this.conf;
+  }
+
+  public setConfig(conf: CheckCommentsConf) {
+    this.conf = conf;
+  }
+
+  public runParsed(file: ABAPFile): Issue[] {
+    const issues: Issue[] = [];
+    const rows = file.getRawRows();
+    if (this.conf.allowEndOfLine === true) {
+      return [];
+    }
+    const rowsWithComments: number[] = [];
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      if (row.trim().startsWith("*") || row.trim().startsWith(`"`)) {
+        rowsWithComments.push(i);
+      }
+    }
+    const statements = file.getStatements();
+    for (let i = statements.length - 1; i >= 0; i--) {
+      const statement = statements[i];
+      if (statement.get() instanceof Comment && !rowsWithComments.includes(statement.getStart().getRow() - 1)) {
+        issues.push(
+          Issue.atStatement(
+            file,
+            statement,
+            this.getDescription(IssueType.EndOfLine),
+            this.getKey()));
+      }
+    }
+    return issues;
+  }
+}

--- a/src/rules/check_comments.ts
+++ b/src/rules/check_comments.ts
@@ -42,17 +42,17 @@ export class CheckComments extends ABAPRule {
     if (this.conf.allowEndOfLine === true) {
       return [];
     }
-    const rowsWithComments: number[] = [];
+    const commentRows: number[] = [];
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i];
       if (row.trim().startsWith("*") || row.trim().startsWith(`"`)) {
-        rowsWithComments.push(i);
+        commentRows.push(i);
       }
     }
     const statements = file.getStatements();
     for (let i = statements.length - 1; i >= 0; i--) {
       const statement = statements[i];
-      if (statement.get() instanceof Comment && !rowsWithComments.includes(statement.getStart().getRow() - 1)) {
+      if (statement.get() instanceof Comment && !commentRows.includes(statement.getStart().getRow() - 1)) {
         issues.push(
           Issue.atStatement(
             file,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -6,6 +6,7 @@ export * from "./avoid_use";
 export * from "./breakpoint";
 export * from "./chain_mainly_declarations";
 export * from "./check_abstract";
+export * from "./check_comments";
 export * from "./check_no_handler_pragma";
 export * from "./check_text_elements";
 export * from "./cloud_types";

--- a/test/rules/check_comments.ts
+++ b/test/rules/check_comments.ts
@@ -1,0 +1,138 @@
+import {CheckCommentsConf, CheckComments} from "../../src/rules/check_comments";
+import {testRuleWithVariableConfig} from "./_utils";
+
+
+const configNoEndOfLine = new CheckCommentsConf();
+configNoEndOfLine.allowEndOfLine = false;
+
+const configEndOfLineAllowed = new CheckCommentsConf();
+configEndOfLineAllowed.allowEndOfLine = true;
+
+const testCases: String[] = [
+  ` REPORT yfoo. " inline comment `,
+
+  ` REPORT yfoo. " inline comment
+    " normal comment
+    WRITE 'abc'.`,
+
+  ` REPORT yfoo.
+    * asterisk comment
+    WRITE 'abc'.`,
+  ` REPORT yfoo.
+    WRITE ' "abc'.
+    DATA(date) = cl_reca_date=>add_to_date( id_days = 1
+                                            id_date = sy-datum ). "today `,
+
+  ` SELECT kna1~kunnr, "test
+      kna1~name1 "test
+      kna1~ort01 "test
+      kna1~stras "test
+      kna1~pstlz "test
+      kna1~stceg "test
+    FROM kna1 "test
+    INTO TABLE mt_selection "test
+    WHERE kna1~ktokd = 'ZAG' "test
+      AND kna1~sperr = ' ' "test
+      AND kna1~sperz = ' ' "test
+    GROUP BY kunnr name1 ort01 stras pstlz stceg. "test`,
+
+  ` WRITE: ' "fake comment '.
+    WRITE: | "another fake comment  "test|.
+    WRITE: '"fake comment'. "real comment
+    WRITE: | "fake '"comment'|. "real comment`,
+
+  ` CLASS zcl_foo DEFINITION CREATE PUBLIC.
+      PUBLIC SECTION.
+        "!abapdoc
+        METHODS foo.
+    ENDCLASS.`,
+];
+
+const checkCommentsTests = [
+  {
+    abap: testCases[0],
+    description: "no end of line, with end of line",
+    config: configNoEndOfLine,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[0],
+    description: "end of line allowed, with end of line",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[1],
+    description: "no end of line, normal comment + end of line",
+    config: configNoEndOfLine,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[1],
+    description: "end of line allowed, normal comment + end of line",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[2],
+    description: "no end of line, asterisk comment",
+    config: configNoEndOfLine,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[2],
+    description: "end of line allowed, asterisk comment",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[3],
+    description: "no end of line, inline after expr",
+    config: configNoEndOfLine,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[3],
+    description: "end of line allowed, inline after expr",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[4],
+    description: "no end of line, select, multiple comments",
+    config: configNoEndOfLine,
+    issueLength: 12,
+  },
+  {
+    abap: testCases[4],
+    description: "end of line allowed, select, multiple comments",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[5],
+    description: "no end of line, writes with strings",
+    config: configNoEndOfLine,
+    issueLength: 2,
+  },
+  {
+    abap: testCases[5],
+    description: "end of line allowed, writes with strings",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[6],
+    description: "no end of line, abapdoc",
+    config: configNoEndOfLine,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[6],
+    description: "end of line allowed, abapdoc",
+    config: configEndOfLineAllowed,
+    issueLength: 0,
+  },
+];
+
+testRuleWithVariableConfig(checkCommentsTests, CheckComments);


### PR DESCRIPTION
- initially only check for end-of-line comments (part of #633)
(approach may be a bit "hacky", might be solved with a regex instead?)