### PR TITLE
Local Class Naming: Add option for Exception classes + Refactoring

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -2038,6 +2038,10 @@
           "description": "Is the rule enabled?",
           "type": "boolean"
         },
+        "exception": {
+          "description": "The pattern for local exception names",
+          "type": "string"
+        },
         "exclude": {
           "description": "List of file regex patterns to exclude",
           "items": {
@@ -2078,6 +2082,7 @@
       },
       "required": [
         "local",
+        "exception",
         "test"
       ],
       "type": "object"

--- a/src/rules/naming/local_class_naming.ts
+++ b/src/rules/naming/local_class_naming.ts
@@ -1,11 +1,6 @@
 import {Issue} from "../../issue";
 import {ABAPRule} from "../_abap_rule";
 import {ABAPFile} from "../../files";
-import {ClassDefinition} from "../../abap/statements";
-import {IObject} from "../../objects/_iobject";
-import {Registry} from "../../registry";
-import {ClassName} from "../../abap/expressions";
-import {Class} from "../../objects";
 import {NamingRuleConfig} from "../_naming_rule_config";
 import {NameValidator} from "../../utils/name_validator";
 
@@ -13,6 +8,8 @@ import {NameValidator} from "../../utils/name_validator";
 export class LocalClassNamingConf extends NamingRuleConfig {
   /** The pattern for local class names */
   public local: string = "^LCL_.+$";
+  /** The pattern for local exception names */
+  public exception: string = "^LCX_.+$";
   /** The pattern for local test class names */
   public test: string = "^LTCL_.+$";
 }
@@ -28,7 +25,7 @@ export class LocalClassNaming extends ABAPRule {
   private getDescription(expected: string, actual: string): string {
     return this.conf.patternKind === "required" ?
       "Local class name does not match pattern " + expected + ": " + actual :
-      "Local class name must not match pattern " + expected + ": " + actual ;
+      "Local class name must not match pattern " + expected + ": " + actual;
   }
 
   public getConfig(): LocalClassNamingConf {
@@ -39,43 +36,34 @@ export class LocalClassNaming extends ABAPRule {
     this.conf = conf;
   }
 
-  public runParsed(file: ABAPFile, _reg: Registry, obj: IObject) {
+  public runParsed(file: ABAPFile): Issue[] {
     const issues: Issue[] = [];
-    const testRegex = new RegExp(this.conf.test, "i");
-    const localRegex = new RegExp(this.conf.local, "i");
 
-    for (const stat of file.getStatements()) {
-      if (!(stat.get() instanceof ClassDefinition)) {
+    for (const classDef of file.getClassDefinitions()) {
+      if (classDef.isGlobal()) {
         continue;
       }
 
-      const expr = stat.findFirstExpression(ClassName);
-      if (!expr) {
-        continue;
-      }
-      const token = expr.getFirstToken();
-      const name = token.getStr();
-      if (obj instanceof Class && name.toUpperCase() === obj.getName().toUpperCase()) {
-        continue;
-      }
-
+      const className = classDef.getName();
       let expected = "";
-      if (stat.concatTokens().toUpperCase().includes("FOR TESTING")) {
-        if (NameValidator.violatesRule(name, testRegex, this.conf)) {
-          expected = this.conf.test;
-        }
-      } else {
-        if (NameValidator.violatesRule(name, localRegex, this.conf)) {
-          expected = this.conf.local;
-        }
-      }
 
-      if (expected.length > 0) {
-        const issue = Issue.atToken(file, token, this.getDescription(expected, name), this.getKey());
-        issues.push(issue);
+      if (classDef.isForTesting()) {
+        expected = this.conf.test;
+      } else if (classDef.isException()) {
+        expected = this.conf.exception;
+      } else {
+        expected = this.conf.local;
+      }
+      const regex = new RegExp(expected, "i");
+
+      if (NameValidator.violatesRule(className, regex, this.conf)) {
+        issues.push(
+          Issue.atIdentifier(
+            classDef,
+            this.getDescription(expected, className),
+            this.getKey()));
       }
     }
-
     return issues;
   }
 

--- a/src/rules/naming/local_class_naming.ts
+++ b/src/rules/naming/local_class_naming.ts
@@ -54,6 +54,9 @@ export class LocalClassNaming extends ABAPRule {
       } else {
         expected = this.conf.local;
       }
+      if (expected.length === 0) {
+        continue;
+      }
       const regex = new RegExp(expected, "i");
 
       if (NameValidator.violatesRule(className, regex, this.conf)) {

--- a/test/rules/naming/local_class_naming.ts
+++ b/test/rules/naming/local_class_naming.ts
@@ -11,6 +11,10 @@ const requiredPatternTests = [
     "endclass.", cnt: 1},
   {abap: "class hello_world definition final.\n" +
     "endclass.", cnt: 1},
+  {abap: "class lcx_except definition inheriting from cx_static_check.\n" +
+    "endclass.", cnt: 0},
+  {abap: "class exception_foo definition inheriting from cx_static_check.\n" +
+    "endclass.", cnt: 1},
 ];
 
 testRule(requiredPatternTests, LocalClassNaming);
@@ -24,9 +28,14 @@ const forbiddenPatternTests = [
     "endclass.", cnt: 0},
   {abap: "class hello_world definition final.\n" +
     "endclass.", cnt: 0},
+  {abap: "class lcx_except definition inheriting from cx_static_check.\n" +
+    "endclass.", cnt: 1},
+  {abap: "class exception_foo definition inheriting from cx_static_check.\n" +
+    "endclass.", cnt: 0},
 ];
 const config = new LocalClassNamingConf();
 config.local = "^lcl_.*$";
 config.test = "^ltcl_.*$";
+config.exception = "^lcx_.*$";
 config.patternKind = "forbidden";
 testRule(forbiddenPatternTests, LocalClassNaming, config);


### PR DESCRIPTION
- Added option `exception` to rule `local_class_naming` (resolves #400)
- refactored the rule logic to use newer constructs (makes it more readable)