### PR TITLE
Pretty Printer: Trailing whitespace

### DIFF
--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -17,7 +17,7 @@ import {Definition} from "./definition";
 export class LanguageServer {
   private readonly reg: Registry;
 
-  constructor (reg: Registry) {
+  constructor(reg: Registry) {
     this.reg = reg;
   }
 
@@ -37,13 +37,15 @@ export class LanguageServer {
     return undefined;
   }
 
-// go to definition
+  // go to definition
   public definition(params: {textDocument: LServer.TextDocumentIdentifier, position: LServer.Position}): LServer.Location | undefined {
     return Definition.find(this.reg, params.textDocument, params.position);
   }
 
-  public documentFormatting(params: {textDocument: LServer.TextDocumentIdentifier,
-    options?: LServer.FormattingOptions}): LServer.TextEdit[] {
+  public documentFormatting(params: {
+    textDocument: LServer.TextDocumentIdentifier,
+    options?: LServer.FormattingOptions,
+  }): LServer.TextEdit[] {
 
     const file = this.reg.getABAPFile(params.textDocument.uri);
     if (file === undefined) {
@@ -51,11 +53,9 @@ export class LanguageServer {
     }
 
     const text = new PrettyPrinter(file, this.reg.getConfig()).run();
-    const tokens = file.getTokens();
-    const last = tokens[tokens.length - 1];
 
     return [{
-      range: LServer.Range.create(0, 0, last.getRow(), last.getCol() + last.getStr().length),
+      range: LServer.Range.create(0, 0, Number.MAX_VALUE, 0),
       newText: text,
     }];
   }

--- a/src/pretty_printer/remove_sequential_blanks.ts
+++ b/src/pretty_printer/remove_sequential_blanks.ts
@@ -48,7 +48,7 @@ export class RemoveSequentialBlanks {
       return rowsToRemove.indexOf(idx) === -1;
     });
 
-    return withoutRemoved.join("\n");
+    return withoutRemoved.join("\n").trim();
   }
 
   private getSequentialBlankConfig(): SequentialBlankConf | undefined {

--- a/test/abap/pretty_printer.ts
+++ b/test/abap/pretty_printer.ts
@@ -105,7 +105,11 @@ describe("Remove sequential blanks", () => {
       expected: "REPORT zfoo.\n\n\n\nWRITE: `foo`.\n\n\n\nWRITE: 'bar'",
     },
     {
-      input: "REPORT zfoo.\n\t\n\n\n\nWRITE: `foo`.\n\n\t\n\n\nWRITE: 'bar'", // todo trim trailing whitespace
+      input: "REPORT zfoo.\n\t\n\n\n\nWRITE: `foo`.\n\n\t\n\n\nWRITE: 'bar'",
+      expected: "REPORT zfoo.\n\t\n\n\nWRITE: `foo`.\n\n\t\n\nWRITE: 'bar'",
+    },
+    {
+      input: "REPORT zfoo.\n\t\n\n\n\nWRITE: `foo`.\n\n\t\n\n\nWRITE: 'bar'    \n\n\n\n\n\n",
       expected: "REPORT zfoo.\n\t\n\n\nWRITE: `foo`.\n\n\t\n\nWRITE: 'bar'",
     },
   ];


### PR DESCRIPTION
- Remove trailing (and leading) whitespace with a simple trim (tries to resolve #564)
- The effect in the playground is that no new lines are added - but the trailing whitespace is NOT removed. The cause could lie within mono/language server itself?

![pretty_print](https://user-images.githubusercontent.com/27279305/69865659-18e6c400-12a2-11ea-8a6c-6cc492c3328d.gif)
