### PR TITLE
New Rule: Fully type Constants (and data definitions)

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -834,8 +834,10 @@
     },
     "FullyTypeConsantsConf": {
       "additionalProperties": false,
+      "description": "Checks constants for full typing - no implicit typing allowed.",
       "properties": {
         "checkData": {
+          "description": "Add check for implicit data definition, require full typing.",
           "type": "boolean"
         },
         "enabled": {

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -832,6 +832,33 @@
       },
       "type": "object"
     },
+    "FullyTypeConsantsConf": {
+      "additionalProperties": false,
+      "properties": {
+        "checkData": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Is the rule enabled?",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "List of file regex patterns to exclude",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reason": {
+          "description": "An explanation for why the rule is enforced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "checkData"
+      ],
+      "type": "object"
+    },
     "FunctionalWritingConf": {
       "additionalProperties": false,
       "description": "Detects usage of call method when functional style calls can be used.",
@@ -1211,6 +1238,16 @@
               "anyOf": [
                 {
                   "$ref": "#/definitions/FormTablesObsoleteConf"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "fully_type_constants": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FullyTypeConsantsConf"
                 },
                 {
                   "type": "boolean"

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -31,6 +31,7 @@ import {ExitOrCheckConf} from "../src/rules/exit_or_check";
 import {ExportingConf} from "../src/rules/exporting";
 import {FormNoDashConf} from "../src/rules/form_no_dash";
 import {FormTablesObsoleteConf} from "../src/rules/form_tables_obsolete";
+import {FullyTypeConsantsConf} from "../src/rules/fully_type_constants";
 import {FunctionalWritingConf} from "../src/rules/functional_writing";
 import {GlobalClassConf} from "../src/rules/syntax/global_class";
 import {IdenticalFormNamesConf} from "../src/rules/identical_form_names";
@@ -114,6 +115,7 @@ export interface IConfig {
     "exporting"?: ExportingConf | boolean,
     "form_no_dash"?: FormNoDashConf | boolean,
     "form_tables_obsolete"?: FormTablesObsoleteConf | boolean,
+    "fully_type_constants"?: FullyTypeConsantsConf | boolean,
     "functional_writing"?: FunctionalWritingConf | boolean,
     "global_class"?: GlobalClassConf | boolean,
     "identical_form_names"?: IdenticalFormNamesConf | boolean,

--- a/src/rules/fully_type_constants.ts
+++ b/src/rules/fully_type_constants.ts
@@ -1,0 +1,50 @@
+import {BasicRuleConfig} from "./_basic_rule_config";
+import {ABAPRule} from "./_abap_rule";
+import {ABAPFile} from "../files";
+import {Issue} from "..";
+import * as Statements from "../abap/statements";
+import {Type} from "../abap/expressions";
+
+// todo jsdoc
+export class FullyTypeConsantsConf extends BasicRuleConfig {
+  // todo jsdoc
+  public checkData: boolean = true;
+}
+
+export class FullyTypeConstants extends ABAPRule {
+  private conf = new FullyTypeConsantsConf();
+
+  public getKey(): string {
+    return "fully_type_constants";
+  }
+
+  public getDescription(type: string): string {
+    return `Fully type ${type} (no implicit typing).`;
+  }
+
+  public getConfig(): FullyTypeConsantsConf {
+    return this.conf;
+  }
+
+  public setConfig(conf: FullyTypeConsantsConf): void {
+    this.conf = conf;
+  }
+
+  public runParsed(file: ABAPFile): Issue[] {
+    const issues: Issue[] = [];
+
+    for (const stat of file.getStatements()) {
+      if ((stat.get() instanceof Statements.Constant
+          || (this.conf.checkData === true && stat.get() instanceof Statements.Data))
+          && (!stat.findFirstExpression(Type))) {
+        issues.push(
+          Issue.atStatement(
+            file,
+            stat,
+            this.getDescription(stat.getFirstToken().getStr()),
+            this.getKey()));
+      }
+    }
+    return issues;
+  }
+}

--- a/src/rules/fully_type_constants.ts
+++ b/src/rules/fully_type_constants.ts
@@ -19,7 +19,7 @@ export class FullyTypeConstants extends ABAPRule {
   }
 
   public getDescription(type: string): string {
-    return `Fully type ${type} (no implicit typing).`;
+    return `Fully type ${type}, no implicit typing`;
   }
 
   public getConfig(): FullyTypeConsantsConf {
@@ -37,11 +37,12 @@ export class FullyTypeConstants extends ABAPRule {
       if ((stat.get() instanceof Statements.Constant
           || (this.conf.checkData === true && stat.get() instanceof Statements.Data))
           && (!stat.findFirstExpression(Type))) {
+        const type = stat.get() instanceof Statements.Constant ? "constant definition" : "data definition";
         issues.push(
           Issue.atStatement(
             file,
             stat,
-            this.getDescription(stat.getFirstToken().getStr()),
+            this.getDescription(type),
             this.getKey()));
       }
     }

--- a/src/rules/fully_type_constants.ts
+++ b/src/rules/fully_type_constants.ts
@@ -5,9 +5,9 @@ import {Issue} from "..";
 import * as Statements from "../abap/statements";
 import {Type} from "../abap/expressions";
 
-// todo jsdoc
+/** Checks constants for full typing - no implicit typing allowed. */
 export class FullyTypeConsantsConf extends BasicRuleConfig {
-  // todo jsdoc
+  /** Add check for implicit data definition, require full typing. */
   public checkData: boolean = true;
 }
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -21,6 +21,7 @@ export * from "./exit_or_check";
 export * from "./exporting";
 export * from "./form_no_dash";
 export * from "./form_tables_obsolete";
+export * from "./fully_type_constants";
 export * from "./functional_writing";
 export * from "./identical_form_names";
 export * from "./if_in_if";

--- a/test/registry.ts
+++ b/test/registry.ts
@@ -73,7 +73,7 @@ describe("Registry", () => {
   });
 
   it("Add and update", () => {
-    const file = new MemoryFile("zfoobar.prog.abap", "REPORT zfoobar.\nDATA hello.\nWRITE hello.");
+    const file = new MemoryFile("zfoobar.prog.abap", "REPORT zfoobar.\nDATA hello TYPE i.\nWRITE hello.");
     const registry = new Registry().addFile(file);
     expect(registry.findIssues().length).to.equal(0);
 

--- a/test/rules/fully_type_constants.ts
+++ b/test/rules/fully_type_constants.ts
@@ -1,0 +1,128 @@
+import {FullyTypeConsantsConf, FullyTypeConstants} from "../../src/rules/fully_type_constants";
+import {testRuleWithVariableConfig} from "./_utils";
+
+const configOnlyConstants = new FullyTypeConsantsConf();
+configOnlyConstants.checkData = false;
+
+const configDataAndConstants = new FullyTypeConsantsConf();
+configDataAndConstants.checkData = true;
+
+const testCases: String[] = [
+  `CONSTANTS: tested_name VALUE \`blah\`.`,
+  `CONSTANTS: tested_name3 VALUE 1234.`,
+  `DATA: foo VALUE 124.`,
+  `DATA: foo VALUE \`blah\`.`,
+  `CONSTANTS foo TYPE i VALUE 1.`,
+  `DATA foo TYPE i VALUE 1.`,
+
+  `CONSTANTS: BEGIN OF c_multi,
+    foo VALUE 1,
+    bar TYPE i VALUE 1,
+   END OF c_multi.`,
+
+  `DATA: BEGIN OF multi,
+    foo VALUE 1,
+    bar TYPE i VALUE 1,
+  END OF multi.`,
+];
+
+const fullyTypeTests = [
+  {
+    abap: testCases[0],
+    description: "only const, const string no type ",
+    config: configOnlyConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[0],
+    description: "both, const string no type",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[1],
+    description: "only const, const number no type ",
+    config: configOnlyConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[1],
+    description: "both, const number no type",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[2],
+    description: "only const, data number no type ",
+    config: configOnlyConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[2],
+    description: "both, data number no type",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[3],
+    description: "only const, data string no type ",
+    config: configOnlyConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[3],
+    description: "both, data string no type",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[4],
+    description: "only const, const with type",
+    config: configOnlyConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[4],
+    description: "both, const with type",
+    config: configDataAndConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[5],
+    description: "only const, data with type",
+    config: configOnlyConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[5],
+    description: "both, data with type",
+    config: configDataAndConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[6],
+    description: "only const, const struc, one not typed",
+    config: configOnlyConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[6],
+    description: "both, const struc, one not typed",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+  {
+    abap: testCases[7],
+    description: "only const, data struc, one not typed",
+    config: configOnlyConstants,
+    issueLength: 0,
+  },
+  {
+    abap: testCases[7],
+    description: "both, data struc, one not typed",
+    config: configDataAndConstants,
+    issueLength: 1,
+  },
+];
+
+testRuleWithVariableConfig(fullyTypeTests, FullyTypeConstants);


### PR DESCRIPTION
- Checks for implicit typing of Constants (and data definitions, if option enabled), first part of #540