### PR TITLE
New Rule: Selection-Screen variable naming 

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -1608,6 +1608,16 @@
                 }
               ]
             },
+            "selection_screen_naming": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SelectionScreenNamingConf"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
             "sequential_blank": {
               "anyOf": [
                 {
@@ -2914,6 +2924,57 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "SelectionScreenNamingConf": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Is the rule enabled?",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "List of file regex patterns to exclude",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ignoreNames": {
+          "description": "A list of names to be ignored",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ignorePatterns": {
+          "description": "A list of patterns to be ignored. For example, you can use it to ignore ambiguous prefixes",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "parameter": {
+          "description": "The pattern for selection-screen parameters",
+          "type": "string"
+        },
+        "patternKind": {
+          "$ref": "#/definitions/PatternKind",
+          "description": "Specifies whether the pattern is forbidden (violation if name matches) or required (violation if name does not match)."
+        },
+        "reason": {
+          "description": "An explanation for why the rule is enforced",
+          "type": "string"
+        },
+        "selectOption": {
+          "description": "The pattern for selection-screen select-options",
+          "type": "string"
+        }
+      },
+      "required": [
+        "parameter",
+        "selectOption"
+      ],
       "type": "object"
     },
     "SequentialBlankConf": {

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -2928,6 +2928,7 @@
     },
     "SelectionScreenNamingConf": {
       "additionalProperties": false,
+      "description": "Allows you to enforce a pattern, such as a prefix, for selection-screen variable names.",
       "properties": {
         "enabled": {
           "description": "Is the rule enabled?",

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -64,6 +64,7 @@ import {PreferredCompareOperatorConf} from "../src/rules/preferred_compare_opera
 import {ReleaseIdocConf} from "../src/rules/release_idoc";
 import {RemoveDescriptionsConf} from "../src/rules/remove_descriptions";
 import {RFCErrorHandlingConf} from "../src/rules/rfc_error_handling";
+import {SelectionScreenNamingConf} from "../src/rules/naming/selection_screen_naming";
 import {SequentialBlankConf} from "../src/rules/whitespace/sequential_blank";
 import {ShortCaseConf} from "../src/rules/short_case";
 import {SICFConsistencyConf} from "../src/rules/sicf_consistency";
@@ -151,6 +152,7 @@ export interface IConfig {
     "release_idoc"?: ReleaseIdocConf | boolean,
     "remove_descriptions"?: RemoveDescriptionsConf | boolean,
     "rfc_error_handling"?: RFCErrorHandlingConf | boolean,
+    "selection_screen_naming"?: SelectionScreenNamingConf | boolean,
     "sequential_blank"?: SequentialBlankConf | boolean,
     "short_case"?: ShortCaseConf | boolean,
     "sicf_consistency"?: SICFConsistencyConf | boolean,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -41,6 +41,7 @@ export * from "./naming/local_class_naming";
 export * from "./naming/local_variable_names";
 export * from "./naming/method_parameter_names";
 export * from "./naming/object_naming";
+export * from "./naming/selection_screen_naming";
 export * from "./naming/types_naming";
 export * from "./nesting";
 export * from "./no_public_attributes";

--- a/src/rules/naming/selection_screen_naming.ts
+++ b/src/rules/naming/selection_screen_naming.ts
@@ -44,10 +44,10 @@ export class SelectionScreenNaming extends ABAPRule {
     }
     let parameterCheckDisabled: boolean = false;
     let selectOptionDisabled: boolean = false;
-    if (this.conf.parameter.length === 0 || this.conf.parameter === undefined) {
+    if (this.conf.parameter === undefined || this.conf.parameter.length === 0) {
       parameterCheckDisabled = true;
     }
-    if (this.conf.selectOption.length === 0 || this.conf.selectOption === undefined) {
+    if (this.conf.selectOption === undefined || this.conf.selectOption.length === 0) {
       selectOptionDisabled = true;
     }
 

--- a/src/rules/naming/selection_screen_naming.ts
+++ b/src/rules/naming/selection_screen_naming.ts
@@ -39,6 +39,9 @@ export class SelectionScreenNaming extends ABAPRule {
 
   public runParsed(file: ABAPFile) {
     const issues: Issue[] = [];
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
     let parameterCheckDisabled: boolean = false;
     let selectOptionDisabled: boolean = false;
     if (this.conf.parameter.length === 0 || this.conf.parameter === undefined) {

--- a/src/rules/naming/selection_screen_naming.ts
+++ b/src/rules/naming/selection_screen_naming.ts
@@ -1,0 +1,87 @@
+import {ABAPRule} from "./../_abap_rule";
+import {ABAPFile} from "../../files";
+import {Issue} from "../../";
+import {NamingRuleConfig} from "../_naming_rule_config";
+import {Parameter, SelectOption} from "../../abap/statements";
+import {Statement} from "../../abap/statements/_statement";
+import {NameValidator} from "../../utils/name_validator";
+import {FieldSub, Field} from "../../abap/expressions";
+import {StatementNode, ExpressionNode} from "../../abap/nodes";
+
+/** Allows you to enforce a pattern, such as a prefix, for selection-screen variable names. */
+export class SelectionScreenNamingConf extends NamingRuleConfig {
+  /** The pattern for selection-screen parameters */
+  public parameter: string = "^P_.+$";
+  /** The pattern for selection-screen select-options */
+  public selectOption: string = "^S_.+$";
+}
+export class SelectionScreenNaming extends ABAPRule {
+
+  private conf = new SelectionScreenNamingConf();
+
+  public getKey(): string {
+    return "selection_screen_naming";
+  }
+
+  private getDescription(expected: string, actual: string): string {
+    return this.conf.patternKind === "required" ?
+      `Selection-Screen variable name does not match pattern ${expected}: ${actual}` :
+      `Selection-Screen variable name must not match pattern ${expected}: ${actual}`;
+  }
+
+  public getConfig() {
+    return this.conf;
+  }
+
+  public setConfig(conf: SelectionScreenNamingConf) {
+    this.conf = conf;
+  }
+
+  public runParsed(file: ABAPFile) {
+    const issues: Issue[] = [];
+    let parameterCheckDisabled: boolean = false;
+    let selectOptionDisabled: boolean = false;
+    if (this.conf.parameter.length === 0) {
+      parameterCheckDisabled = true;
+    }
+    if (this.conf.selectOption.length === 0) {
+      selectOptionDisabled = true;
+    }
+
+    for (const stat of file.getStatements()) {
+      if ((stat.get() instanceof Parameter && !parameterCheckDisabled)
+          || (stat.get() instanceof SelectOption && !selectOptionDisabled)) {
+        const fieldNode = this.getFieldForStatement(stat);
+        const regex = new RegExp(this.getPatternForStatement(stat.get()), "i");
+        if (fieldNode && NameValidator.violatesRule(fieldNode.getFirstToken().getStr(), regex, this.conf)) {
+          issues.push(Issue.atToken(
+            file,
+            fieldNode.getFirstToken(),
+            this.getDescription(this.getPatternForStatement(stat.get()), fieldNode.getFirstToken().getStr()),
+            this.getKey()));
+        }
+      }
+    }
+    return issues;
+  }
+
+  private getPatternForStatement(statement: Statement): string {
+    let pattern = "";
+    if (statement instanceof Parameter) {
+      pattern = this.conf.parameter;
+    } else if (statement instanceof SelectOption) {
+      pattern = this.conf.selectOption;
+    }
+    return pattern;
+  }
+
+  private getFieldForStatement(statNode: StatementNode): ExpressionNode | undefined {
+    if (statNode.get() instanceof Parameter) {
+      return statNode.findFirstExpression(FieldSub);
+    } else if (statNode.get() instanceof SelectOption) {
+      return statNode.findFirstExpression(Field);
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/src/rules/naming/selection_screen_naming.ts
+++ b/src/rules/naming/selection_screen_naming.ts
@@ -41,10 +41,10 @@ export class SelectionScreenNaming extends ABAPRule {
     const issues: Issue[] = [];
     let parameterCheckDisabled: boolean = false;
     let selectOptionDisabled: boolean = false;
-    if (this.conf.parameter.length === 0) {
+    if (this.conf.parameter.length === 0 || this.conf.parameter === undefined) {
       parameterCheckDisabled = true;
     }
-    if (this.conf.selectOption.length === 0) {
+    if (this.conf.selectOption.length === 0 || this.conf.selectOption === undefined) {
       selectOptionDisabled = true;
     }
 

--- a/src/rules/naming/selection_screen_naming.ts
+++ b/src/rules/naming/selection_screen_naming.ts
@@ -51,7 +51,7 @@ export class SelectionScreenNaming extends ABAPRule {
     for (const stat of file.getStatements()) {
       if ((stat.get() instanceof Parameter && !parameterCheckDisabled)
           || (stat.get() instanceof SelectOption && !selectOptionDisabled)) {
-        const fieldNode = this.getFieldForStatement(stat);
+        const fieldNode = this.getFieldForStatementNode(stat);
         const regex = new RegExp(this.getPatternForStatement(stat.get()), "i");
         if (fieldNode && NameValidator.violatesRule(fieldNode.getFirstToken().getStr(), regex, this.conf)) {
           issues.push(Issue.atToken(
@@ -75,7 +75,7 @@ export class SelectionScreenNaming extends ABAPRule {
     return pattern;
   }
 
-  private getFieldForStatement(statNode: StatementNode): ExpressionNode | undefined {
+  private getFieldForStatementNode(statNode: StatementNode): ExpressionNode | undefined {
     if (statNode.get() instanceof Parameter) {
       return statNode.findFirstExpression(FieldSub);
     } else if (statNode.get() instanceof SelectOption) {

--- a/test/rules/naming/selection_screen_naming.ts
+++ b/test/rules/naming/selection_screen_naming.ts
@@ -1,0 +1,48 @@
+import {testRule} from "../_utils";
+import {SelectionScreenNaming, SelectionScreenNamingConf} from "../../../src/rules/naming/selection_screen_naming";
+
+
+const requiredPatternTests = [
+  {abap: "parameters p_mat TYPE matnr.", cnt: 0},
+  {abap: "parameters mat TYPE matnr.", cnt: 1},
+  {abap: "parameters s_mat TYPE matnr.", cnt: 1},
+  {abap: "select-options s_mat for gv_matnr.", cnt: 0},
+  {abap: "select-options mat for gv_matnr.", cnt: 1},
+  {abap: "select-options p_mat for gv_matnr.", cnt: 1},
+];
+
+const configRequired = new SelectionScreenNamingConf();
+configRequired.parameter = "^P_.+$";
+configRequired.selectOption = "^S_.+$";
+configRequired.patternKind = "required";
+testRule(requiredPatternTests, SelectionScreenNaming, configRequired);
+
+const forbiddenPatternTests = [
+  {abap: "parameters p_mat TYPE matnr.", cnt: 1},
+  {abap: "parameters mat TYPE matnr.", cnt: 0},
+  {abap: "parameters s_mat TYPE matnr.", cnt: 0},
+  {abap: "select-options s_mat for gv_matnr.", cnt: 1},
+  {abap: "select-options mat for gv_matnr.", cnt: 0},
+  {abap: "select-options p_mat for gv_matnr.", cnt: 0},
+];
+
+const configForbidden = new SelectionScreenNamingConf();
+configForbidden.parameter = "^P_.+$";
+configForbidden.selectOption = "^S_.+$";
+configForbidden.patternKind = "forbidden";
+testRule(forbiddenPatternTests, SelectionScreenNaming, configForbidden);
+
+const regexEmptyPatternTests = [
+  {abap: "parameters p_mat TYPE matnr.", cnt: 0},
+  {abap: "parameters mat TYPE matnr.", cnt: 0},
+  {abap: "parameters s_mat TYPE matnr.", cnt: 0},
+  {abap: "select-options s_mat for gv_matnr.", cnt: 0},
+  {abap: "select-options mat for gv_matnr.", cnt: 0},
+  {abap: "select-options p_mat for gv_matnr.", cnt: 0},
+];
+
+const configEmpty = new SelectionScreenNamingConf();
+configEmpty.parameter = "";
+configEmpty.selectOption = "";
+configEmpty.patternKind = "required";
+testRule(regexEmptyPatternTests, SelectionScreenNaming, configEmpty);


### PR DESCRIPTION
- New rule for selection-screen variables (parameters, select-options, resolves #358)
  - default pattern for parameters = `^P_.+$`
  - default pattern for select-options = `^S_.+$`