### PR TITLE
newline_between_methods: clarify description

### DIFF
--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -7,7 +7,7 @@ import {ClassName} from "../abap/expressions";
 
 // todo, unit test missing
 
-/** Reports errors if the current class references itself with "current_class=>" 
+/** Reports errors if the current class references itself with "current_class=>"
  * https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
  */
 export class PrefixIsCurrentClassConf extends BasicRuleConfig {

--- a/src/rules/whitespace/newline_between_methods.ts
+++ b/src/rules/whitespace/newline_between_methods.ts
@@ -32,7 +32,7 @@ export class NewlineBetweenMethods extends ABAPRule {
   private getDescription(): string {
     switch (this.conf.logic) {
       case NewlineLogic.Exact: return `Exactly ${this.conf.count} newlines are required in between methods.`;
-      case NewlineLogic.Less: return `Less than ${this.conf.count} newlines are required in between methods.`;
+      case NewlineLogic.Less: return `Less than ${this.conf.count} newlines and at least a single newline are required in between methods.`;
       default: return "";
     }
   }


### PR DESCRIPTION
- closes #710
- also fixes trailing whitespace for linter