### PR TITLE
PrefixIsCurrentClass:  Add option, tests and refactoring

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -3036,7 +3036,8 @@
           },
           "type": "array"
         },
-        "omitMe": {
+        "omitMeInstanceCalls": {
+          "description": "Checks usages of self references with 'me' when calling instance methods",
           "type": "boolean"
         },
         "reason": {
@@ -3045,7 +3046,7 @@
         }
       },
       "required": [
-        "omitMe"
+        "omitMeInstanceCalls"
       ],
       "type": "object"
     },

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -1673,7 +1673,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Reports errors if the current class references itself with \"current_class=>\""
+              "description": "Reports errors if the current class references itself with \"current_class=>\"\r\nhttps://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method"
             },
             "release_idoc": {
               "anyOf": [
@@ -3023,7 +3023,7 @@
     },
     "PrefixIsCurrentClassConf": {
       "additionalProperties": false,
-      "description": "Reports errors if the current class references itself with \"current_class=>\"",
+      "description": "Reports errors if the current class references itself with \"current_class=>\"\r\nhttps://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method",
       "properties": {
         "enabled": {
           "description": "Is the rule enabled?",
@@ -3036,11 +3036,17 @@
           },
           "type": "array"
         },
+        "omitMe": {
+          "type": "boolean"
+        },
         "reason": {
           "description": "An explanation for why the rule is enforced",
           "type": "string"
         }
       },
+      "required": [
+        "omitMe"
+      ],
       "type": "object"
     },
     "RFCErrorHandlingConf": {

--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -7,7 +7,7 @@ import {Pragma} from "../tokens/pragma";
 import {TokenNode} from "./token_node";
 import {ExpressionNode} from "./expression_node";
 import {Expression} from "../combi";
-import {String, StringTemplate} from "../tokens/string";
+import {String, StringTemplate, StringTemplateBegin, StringTemplateMiddle, StringTemplateEnd} from "../tokens/string";
 import {Comment} from "../tokens/comment";
 
 export class StatementNode extends AbstractNode {
@@ -107,7 +107,12 @@ export class StatementNode extends AbstractNode {
     let str = "";
     let prev: Token | undefined;
     for (const token of this.getTokens()) {
-      if (token instanceof Comment || token instanceof String || token instanceof StringTemplate) {
+      if (token instanceof Comment
+          || token instanceof String
+          || token instanceof StringTemplate
+          || token instanceof StringTemplateBegin
+          || token instanceof StringTemplateMiddle
+          || token instanceof StringTemplateEnd) {
         continue;
       }
       if (str === "") {

--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -7,6 +7,8 @@ import {Pragma} from "../tokens/pragma";
 import {TokenNode} from "./token_node";
 import {ExpressionNode} from "./expression_node";
 import {Expression} from "../combi";
+import {String, StringTemplate} from "../tokens/string";
+import {Comment} from "../tokens/comment";
 
 export class StatementNode extends AbstractNode {
   private readonly statement: Statement;
@@ -86,6 +88,26 @@ export class StatementNode extends AbstractNode {
     let prev: Token | undefined;
     for (const token of this.getTokens()) {
       if (token instanceof Pragma) {
+        continue;
+      }
+      if (str === "") {
+        str = token.getStr();
+      } else if (prev && prev.getStr().length + prev.getCol() === token.getCol()
+          && prev.getRow() === token.getRow()) {
+        str = str + token.getStr();
+      } else {
+        str = str + " " + token.getStr();
+      }
+      prev = token;
+    }
+    return str;
+  }
+
+  public concatIdentifierTokens(): string {
+    let str = "";
+    let prev: Token | undefined;
+    for (const token of this.getTokens()) {
+      if (token instanceof Comment || token instanceof String || token instanceof StringTemplate) {
         continue;
       }
       if (str === "") {

--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -103,7 +103,7 @@ export class StatementNode extends AbstractNode {
     return str;
   }
 
-  public concatIdentifierTokens(): string {
+  public concatTokensWithoutStringsAndComments(): string {
     let str = "";
     let prev: Token | undefined;
     for (const token of this.getTokens()) {

--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -47,14 +47,14 @@ export class PrefixIsCurrentClass extends ABAPRule {
       const staticAccess = name + "=>";
 
       for (const s of c.findAllStatementNodes()) {
-        if (s.concatIdentifierTokens().toUpperCase().includes(staticAccess)) {
+        if (s.concatTokensWithoutStringsAndComments().toUpperCase().includes(staticAccess)) {
           issues.push(Issue.atStatement(
             file,
             s,
             "Statement contains reference to current class: \"" + staticAccess + "\"",
             this.getKey()));
         } else if (this.conf.omitMeInstanceCalls === true
-              && s.concatIdentifierTokens().toUpperCase().includes(meAccess)
+              && s.concatTokensWithoutStringsAndComments().toUpperCase().includes(meAccess)
               && s.findFirstExpression(MethodCall)) {
           issues.push(Issue.atStatement(
             file,

--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -3,14 +3,16 @@ import {ABAPRule} from "./_abap_rule";
 import {ABAPFile} from "../files";
 import * as Structures from "../abap/structures";
 import {BasicRuleConfig} from "./_basic_rule_config";
-import {ClassName} from "../abap/expressions";
-
-// todo, unit test missing
+import {ClassName, MethodCall} from "../abap/expressions";
 
 /** Reports errors if the current class references itself with "current_class=>"
- * https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
  */
 export class PrefixIsCurrentClassConf extends BasicRuleConfig {
+  /**
+   * Checks usages of self references with 'me' when calling instance methods
+   * https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
+   */
+  public omitMeInstanceCalls: boolean = true;
 }
 
 export class PrefixIsCurrentClass extends ABAPRule {
@@ -36,14 +38,29 @@ export class PrefixIsCurrentClass extends ABAPRule {
       return [];
     }
 
-    for (const c of struc.findAllStructures(Structures.ClassImplementation)) {
+    let classStructures = struc.findAllStructures(Structures.ClassImplementation);
+    classStructures = classStructures.concat(struc.findAllStructures(Structures.ClassDefinition));
+    const meAccess = "ME->";
+
+    for (const c of classStructures) {
       const name = c.findFirstExpression(ClassName)!.getFirstToken().getStr().toUpperCase();
-      const search = name + "=>";
+      const staticAccess = name + "=>";
 
       for (const s of c.findAllStatementNodes()) {
-        if (s.concatTokens().toUpperCase().includes(search)) {
-          const issue = Issue.atToken(file, s.getFirstToken(), "Statement contains \"" + search + "\"", this.getKey());
-          issues.push(issue);
+        if (s.concatIdentifierTokens().toUpperCase().includes(staticAccess)) {
+          issues.push(Issue.atStatement(
+            file,
+            s,
+            "Statement contains reference to current class: \"" + staticAccess + "\"",
+            this.getKey()));
+        } else if (this.conf.omitMeInstanceCalls === true
+              && s.concatIdentifierTokens().toUpperCase().includes(meAccess)
+              && s.findFirstExpression(MethodCall)) {
+          issues.push(Issue.atStatement(
+            file,
+            s,
+            "Omit 'me->' in instance calls",
+            this.getKey()));
         }
       }
     }

--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -6,11 +6,11 @@ import {BasicRuleConfig} from "./_basic_rule_config";
 import {ClassName, MethodCall} from "../abap/expressions";
 
 /** Reports errors if the current class references itself with "current_class=>"
+ *  https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
  */
 export class PrefixIsCurrentClassConf extends BasicRuleConfig {
   /**
    * Checks usages of self references with 'me' when calling instance methods
-   * https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
    */
   public omitMeInstanceCalls: boolean = true;
 }

--- a/test/rules/prefix_is_current_class.ts
+++ b/test/rules/prefix_is_current_class.ts
@@ -51,6 +51,7 @@ const defaultConfigTests = [
             METHOD abc.
               WRITE: | { lcl_moo=>mv_abc } |.
               WRITE: | { mv_abc } |.
+              WRITE: |lcl_moo=>mv_abc{ 2 }lcl_moo=>mv_abc{ 3 }lcl_moo=>mv_abc{ 4 }|.
             ENDMETHOD.
           ENDCLASS.`, cnt: 1,
   },

--- a/test/rules/prefix_is_current_class.ts
+++ b/test/rules/prefix_is_current_class.ts
@@ -1,0 +1,137 @@
+import {testRule} from "./_utils";
+import {PrefixIsCurrentClass, PrefixIsCurrentClassConf} from "../../src/rules";
+
+const defaultConfigTests = [
+
+  {
+    // static reference to own class type
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                TYPES: BEGIN OF ty_foo,
+                         foo TYPE i,
+                       END OF ty_foo.
+                METHODS foobar RETURNING VALUE(rv_string) TYPE zcl_foo=>ty_foo.
+            ENDCLASS.`, cnt: 1,
+  },
+  {
+    // static reference to own class type without class name
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                TYPES: BEGIN OF ty_foo,
+                         foo TYPE i,
+                       END OF ty_foo.
+                METHODS foobar RETURNING VALUE(rv_string) TYPE ty_foo.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.`, cnt: 0,
+  },
+  {
+    // static reference to own class in string and comment
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                DATA(_string) = |zcl_foo=>foo( )|.
+                WRITE: 'zcl_foo=>foo( )'.
+                WRITE: 'foo'. " zcl_foo=>foo( )
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 0,
+  },
+  {
+    // static reference to own class class-method
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+                CLASS-METHODS moobar.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                zcl_foo=>moobar( ).
+              ENDMETHOD.
+
+              METHOD moobar.
+                WRITE: '1'.
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 1,
+  },
+  {
+    // me-> reference instance method
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+                METHODS moobar.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                me->moobar( ).
+              ENDMETHOD.
+
+              METHOD moobar.
+                WRITE: '1'.
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 1,
+  },
+  {
+    // me-> reference instance attribute
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                me->mv_foo = 1.
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 0,
+  },
+];
+
+testRule(defaultConfigTests, PrefixIsCurrentClass);
+
+const meReferenceAllowedTests = [
+  {
+    // me-> reference instance method
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+                METHODS moobar.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                me->moobar( ).
+              ENDMETHOD.
+
+              METHOD moobar.
+                WRITE: '1'.
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 0,
+  },
+  {
+    // me-> reference instance attribute
+    abap: ` CLASS zcl_foo DEFINITION PUBLIC.
+              PUBLIC SECTION.
+                METHODS foobar.
+              PROTECTED SECTION.
+                DATA mv_foo TYPE i.
+            ENDCLASS.
+            CLASS zcl_foo IMPLEMENTATION.
+              METHOD foobar.
+                me->mv_foo = 1.
+              ENDMETHOD.
+            ENDCLASS.`, cnt: 0,
+  },
+];
+
+const confMeAllowed = new PrefixIsCurrentClassConf();
+confMeAllowed.omitMeInstanceCalls = false;
+
+testRule(meReferenceAllowedTests, PrefixIsCurrentClass, confMeAllowed);

--- a/test/rules/prefix_is_current_class.ts
+++ b/test/rules/prefix_is_current_class.ts
@@ -40,6 +40,21 @@ const defaultConfigTests = [
             ENDCLASS.`, cnt: 0,
   },
   {
+    // static reference to own class in string template source
+    abap: ` CLASS lcl_moo DEFINITION.
+            PUBLIC SECTION.
+              METHODS abc.
+            PROTECTED SECTION.
+              CLASS-DATA mv_abc TYPE i.
+          ENDCLASS.
+          CLASS lcl_moo IMPLEMENTATION.
+            METHOD abc.
+              WRITE: | { lcl_moo=>mv_abc } |.
+              WRITE: | { mv_abc } |.
+            ENDMETHOD.
+          ENDCLASS.`, cnt: 1,
+  },
+  {
     // static reference to own class class-method
     abap: ` CLASS zcl_foo DEFINITION PUBLIC.
               PUBLIC SECTION.


### PR DESCRIPTION
- adds unit tests
- adds option `omitMeInstanceCalls` to check `me->` usage in instance method calls (suggestions for a better name for the option are welcome)
- adds another concatTokens method that excludes Strings and Comments (name is also debatable)

closes #721 