### PR TITLE
prefix_is_current_class: issue at position instead of statement

### DIFF
--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -170,6 +170,22 @@ export class StatementNode extends AbstractNode {
     return undefined;
   }
 
+  public findDirectTokenByTextIgnoringCase(text: string): Token | undefined {
+    text = text.toUpperCase();
+    for (const child of this.getChildren()) {
+      if (child instanceof TokenNode) {
+        if (child.get().getStr().toUpperCase() === text) {
+          return child.get();
+        }
+      } else if (child instanceof ExpressionNode) {
+        continue;
+      } else {
+        throw new Error("findDirectTokenByText, unexpected type");
+      }
+    }
+    return undefined;
+  }
+
   public findFirstExpression(type: new () => Expression): ExpressionNode | undefined {
     for (const child of this.getChildren()) {
       if (child.get() instanceof type) {
@@ -202,6 +218,32 @@ export class StatementNode extends AbstractNode {
       }
     }
     return ret;
+  }
+
+  /**
+   * Returns the Position of the first token if the sequence is found,
+   * otherwise undefined. Strings and Comments are ignored in this search.
+   * @param first Text of the first Token
+   * @param second Text of the second Token
+   */
+  public findTokenSequencePosition(first: string, second: string): Position | undefined {
+    let prev: Token | undefined;
+    for (const token of this.getTokens()) {
+      if (token instanceof Comment
+        || token instanceof String
+        || token instanceof StringTemplate
+        || token instanceof StringTemplateBegin
+        || token instanceof StringTemplateMiddle
+        || token instanceof StringTemplateEnd) {
+        continue;
+      }
+      if (prev && token.getStr().toUpperCase() === second && prev?.getStr().toUpperCase() === first.toUpperCase()) {
+        return prev.getStart();
+      } else {
+        prev = token;
+      }
+    }
+    return undefined;
   }
 
   private toTokens(b: INode): Token[] {

--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -170,22 +170,6 @@ export class StatementNode extends AbstractNode {
     return undefined;
   }
 
-  public findDirectTokenByTextIgnoringCase(text: string): Token | undefined {
-    text = text.toUpperCase();
-    for (const child of this.getChildren()) {
-      if (child instanceof TokenNode) {
-        if (child.get().getStr().toUpperCase() === text) {
-          return child.get();
-        }
-      } else if (child instanceof ExpressionNode) {
-        continue;
-      } else {
-        throw new Error("findDirectTokenByText, unexpected type");
-      }
-    }
-    return undefined;
-  }
-
   public findFirstExpression(type: new () => Expression): ExpressionNode | undefined {
     for (const child of this.getChildren()) {
       if (child.get() instanceof type) {

--- a/src/abap/nodes/statement_node.ts
+++ b/src/abap/nodes/statement_node.ts
@@ -214,11 +214,11 @@ export class StatementNode extends AbstractNode {
     let prev: Token | undefined;
     for (const token of this.getTokens()) {
       if (token instanceof Comment
-        || token instanceof String
-        || token instanceof StringTemplate
-        || token instanceof StringTemplateBegin
-        || token instanceof StringTemplateMiddle
-        || token instanceof StringTemplateEnd) {
+          || token instanceof String
+          || token instanceof StringTemplate
+          || token instanceof StringTemplateBegin
+          || token instanceof StringTemplateMiddle
+          || token instanceof StringTemplateEnd) {
         continue;
       }
       if (prev && token.getStr().toUpperCase() === second && prev?.getStr().toUpperCase() === first.toUpperCase()) {

--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -5,6 +5,7 @@ import * as Structures from "../abap/structures";
 import {BasicRuleConfig} from "./_basic_rule_config";
 import {ClassName, MethodCall} from "../abap/expressions";
 
+
 /** Reports errors if the current class references itself with "current_class=>"
  *  https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
  */
@@ -32,7 +33,6 @@ export class PrefixIsCurrentClass extends ABAPRule {
 
   public runParsed(file: ABAPFile) {
     const issues: Issue[] = [];
-
     const struc = file.getStructure();
     if (struc === undefined) {
       return [];
@@ -43,28 +43,35 @@ export class PrefixIsCurrentClass extends ABAPRule {
     const meAccess = "ME->";
 
     for (const c of classStructures) {
-      const name = c.findFirstExpression(ClassName)!.getFirstToken().getStr().toUpperCase();
-      const staticAccess = name + "=>";
+      const className = c.findFirstExpression(ClassName)!.getFirstToken().getStr().toUpperCase();
+      const staticAccess = className + "=>";
 
       for (const s of c.findAllStatementNodes()) {
         if (s.concatTokensWithoutStringsAndComments().toUpperCase().includes(staticAccess)) {
-          issues.push(Issue.atStatement(
-            file,
-            s,
-            "Statement contains reference to current class: \"" + staticAccess + "\"",
-            this.getKey()));
+          const tokenPos = s.findTokenSequencePosition(className, "=>");
+          if (tokenPos) {
+            issues.push(Issue.atPosition(
+              file,
+              tokenPos,
+              "Reference to current class can be omitted: \"" + staticAccess + "\"",
+              this.getKey()));
+          }
         } else if (this.conf.omitMeInstanceCalls === true
-              && s.concatTokensWithoutStringsAndComments().toUpperCase().includes(meAccess)
-              && s.findFirstExpression(MethodCall)) {
-          issues.push(Issue.atStatement(
-            file,
-            s,
-            "Omit 'me->' in instance calls",
-            this.getKey()));
+            && s.concatTokensWithoutStringsAndComments().toUpperCase().includes(meAccess)
+            && s.findFirstExpression(MethodCall)) {
+          const tokenPos = s.findTokenSequencePosition("me", "->");
+          if (tokenPos) {
+            issues.push(Issue.atPosition(
+              file,
+              tokenPos,
+              "Omit 'me->' in instance calls",
+              this.getKey()));
+          }
         }
       }
     }
 
     return issues;
   }
+
 }

--- a/src/rules/prefix_is_current_class.ts
+++ b/src/rules/prefix_is_current_class.ts
@@ -5,7 +5,6 @@ import * as Structures from "../abap/structures";
 import {BasicRuleConfig} from "./_basic_rule_config";
 import {ClassName, MethodCall} from "../abap/expressions";
 
-
 /** Reports errors if the current class references itself with "current_class=>"
  *  https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#omit-the-self-reference-me-when-calling-an-instance-method
  */
@@ -70,8 +69,6 @@ export class PrefixIsCurrentClass extends ABAPRule {
         }
       }
     }
-
     return issues;
   }
-
 }


### PR DESCRIPTION
- report issues at relevant position instead of statement (fixes #727)

![image](https://user-images.githubusercontent.com/27279305/71969105-4d855e00-3206-11ea-992c-b8514fc83d3d.png)
- changed description to `Reference to current class can be omitted: <classname>`
- add helper function to find a token-sequence (for now only two tokens by text)

