### PR TITLE
Commented Code: Fixes + Refactoring

### DIFF
--- a/src/rules/commented_code.ts
+++ b/src/rules/commented_code.ts
@@ -39,7 +39,7 @@ export class CommentedCode extends ABAPRule {
 
     let code = "";
     for (let i = 0; i < rows.length; i++) {
-      if (this.isCommentLine(rows[i]) && rows[i].trim().substr(1) !== "") {
+      if (this.isCommentLine(rows[i])) {
         code = code + rows[i].trim().substr(1) + "\n";
       } else if (code !== "") {
         issues = issues.concat(this.check(code, file, i - 1));

--- a/src/rules/commented_code.ts
+++ b/src/rules/commented_code.ts
@@ -69,6 +69,7 @@ export class CommentedCode extends ABAPRule {
           || statement instanceof Empty
           || statement instanceof Comment)) {
         containsStatement = true;
+        break;
       }
     }
     if (!containsStatement) {

--- a/src/rules/commented_code.ts
+++ b/src/rules/commented_code.ts
@@ -33,22 +33,22 @@ export class CommentedCode extends ABAPRule {
   }
 
   public runParsed(file: ABAPFile) {
-    let output: Issue[] = [];
+    let issues: Issue[] = [];
 
     const rows = file.getRawRows();
 
     let code = "";
     for (let i = 0; i < rows.length; i++) {
-      if (rows[i].substr(0, 1) === "*") {
-        code = code + rows[i].substr(1) + "\n";
+      if (this.isCommentLine(rows[i]) && rows[i].trim().substr(1) !== "") {
+        code = code + rows[i].trim().substr(1) + "\n";
       } else if (code !== "") {
-        output = output.concat(this.check(code, file, i - 1));
+        issues = issues.concat(this.check(code, file, i - 1));
         code = "";
       }
     }
-    output = output.concat(this.check(code, file, rows.length - 1));
+    issues = issues.concat(this.check(code, file, rows.length - 1));
 
-    return output;
+    return issues;
   }
 
   private check(code: string, file: ABAPFile, row: number): Issue[] {
@@ -58,21 +58,29 @@ export class CommentedCode extends ABAPRule {
 
     const reg = new Registry().addFile(new MemoryFile("_foobar.prog.abap", code)).parse();
 
-    const statements = reg.getABAPFiles()[0].getStatements();
-    if (statements.length === 0) {
+    const statementNodes = reg.getABAPFiles()[0].getStatements();
+    if (statementNodes.length === 0) {
       return [];
     }
-    for (const statement of statements) {
-      const type = statement.get();
-      if (type instanceof Unknown
-          || type instanceof Empty
-          || type instanceof Comment) {
-        return [];
+    let containsStatement: boolean = false;
+    for (const statementNode of statementNodes) {
+      const statement = statementNode.get();
+      if (!(statement instanceof Unknown
+          || statement instanceof Empty
+          || statement instanceof Comment)) {
+        containsStatement = true;
       }
+    }
+    if (!containsStatement) {
+      return [];
     }
 
     const position = new Position(row + 1, 1);
     const issue = Issue.atPosition(file, position, this.getDescription(), this.getKey());
     return [issue];
+  }
+
+  private isCommentLine(text: string): boolean {
+    return ((text.substr(0, 1) === "*") || (text.trim().substr(0, 1) === "\"" && text.trim().substr(1, 1) !== "!"));
   }
 }

--- a/test/rules/commented_code.ts
+++ b/test/rules/commented_code.ts
@@ -27,6 +27,24 @@ const tests = [
        "cl_abap_unit_assert=>assert_char_cp(
        "   act = lv_abap
     "      exp = '*MOO*' ).`, cnt: 1},
+  {abap:
+    // abapdoc, allowed
+      `"! todo
+      "!    DATA(lv_abap) = mo_cut->build_meta( ls_generate ).
+      "!
+      "!    cl_abap_unit_assert=>assert_not_initial( lv_abap ).
+         "!cl_abap_unit_assert=>assert_char_cp(
+         "!   act = lv_abap
+      "!      exp = '*MOO*' ).`, cnt: 0},
+  {abap:
+    // mix of abapdoc and standard comments
+        `" todo
+        "    DATA(lv_abap) = mo_cut->build_meta( ls_generate ).
+        "
+        "    cl_abap_unit_assert=>assert_not_initial( lv_abap ).
+           "!cl_abap_unit_assert=>assert_char_cp(
+           "!   act = lv_abap
+        "!      exp = '*MOO*' ).`, cnt: 1},
 ];
 
 testRule(tests, CommentedCode);

--- a/test/rules/commented_code.ts
+++ b/test/rules/commented_code.ts
@@ -5,9 +5,28 @@ const tests = [
   {abap: "parser error", cnt: 0},
   {abap: "WRITE: / 'hello'.", cnt: 0},
   {abap: "* WRITE: / 'hello'.", cnt: 1},
+  {abap: "\" WRITE: / 'hello'.", cnt: 1},
   {abap: "* .", cnt: 0},
   {abap: "* ", cnt: 0},
+  {abap: "\" ", cnt: 0},
   {abap: "* hello", cnt: 0},
+  {abap: "\" hello", cnt: 0},
+  {abap: `
+* todo
+*    DATA(lv_abap) = mo_cut->build_meta( ls_generate ).
+*
+*    cl_abap_unit_assert=>assert_not_initial( lv_abap ).
+*    cl_abap_unit_assert=>assert_char_cp(
+*      act = lv_abap
+*      exp = '*MOO*' ).`, cnt: 1},
+  {abap:
+    `" todo
+    "    DATA(lv_abap) = mo_cut->build_meta( ls_generate ).
+    "
+    "    cl_abap_unit_assert=>assert_not_initial( lv_abap ).
+       "cl_abap_unit_assert=>assert_char_cp(
+       "   act = lv_abap
+    "      exp = '*MOO*' ).`, cnt: 1},
 ];
 
 testRule(tests, CommentedCode);


### PR DESCRIPTION
- added check for inline comments (abapdoc comments excluded)
- refactored some variable names
- added additional test cases
- changed logic:
  - currently: if the comment block contains a single line that is not a statement, it will NOT be reported (see #751, the "todo"-line)
  - new: if the block contains at least a single statement, the block will be reported
- resolves #751