### PR TITLE
Remove duplicate 'enabled' from unused_variables

### DIFF
--- a/src/rules/unused_variables.ts
+++ b/src/rules/unused_variables.ts
@@ -12,7 +12,6 @@ import {Interface} from "../objects";
 
 /** Checks for unused variables */
 export class UnusedVariablesConf extends BasicRuleConfig {
-  public enabled = false;
 }
 
 export class UnusedVariables implements IRule {


### PR DESCRIPTION
Resolves #750.

For some reason this was specified here as well instead of the basic config. Removing the attribute does not change the schema. I think it never worked with the schema in the first place, which is why the warning is there.