### PR TITLE
check_syntax bugfix

### DIFF
--- a/src/abap/expressions/inline_field_definition.ts
+++ b/src/abap/expressions/inline_field_definition.ts
@@ -1,8 +1,9 @@
-import {Expression, IStatementRunnable, seq, str} from "../combi";
-import {Field, Source} from ".";
+import {Expression, IStatementRunnable, seq, str, alt} from "../combi";
+import {Field, Source, TypeName} from ".";
 
 export class InlineFieldDefinition extends Expression {
   public getRunnable(): IStatementRunnable {
-    return seq(new Field(), str("="), new Source());
+    return alt(seq(new Field(), str("="), new Source()),
+               seq(new Field(), str("TYPE"), new TypeName()));
   }
 }

--- a/src/abap/expressions/source.ts
+++ b/src/abap/expressions/source.ts
@@ -1,7 +1,7 @@
 import {plus, ver, seq, opt, tok, str, alt, star, optPrio, regex, Expression, IStatementRunnable} from "../combi";
 import {InstanceArrow, WParenLeftW, WParenRightW, WDashW, ParenLeftW} from "../tokens/";
 import {MethodCallChain, ArithOperator, Cond, Constant, StringTemplate, Let, ComponentCond, SimpleName} from "./";
-import {TypeName, FieldChain, Field, TableBody, TypeNameOrInfer, ArrowOrDash, FieldSub, For, Throw} from "./";
+import {FieldChain, Field, TableBody, TypeNameOrInfer, ArrowOrDash, FieldSub, For, Throw} from "./";
 import {Version} from "../../version";
 import {ComponentChain, ComponentName} from "./";
 import {InlineFieldDefinition} from "./inline_field_definition";
@@ -134,9 +134,8 @@ export class Source extends Expression {
                            rparen));
 
     const fields = seq(new Field(), str("="), new Source());
-    const inittype = seq(new Field(), str("TYPE"), new TypeName());
 
-    const init = seq(str("INIT"), plus(alt(new InlineFieldDefinition(), inittype)));
+    const init = seq(str("INIT"), plus(new InlineFieldDefinition()));
 
     const reduce = ver(Version.v740sp08,
                        seq(str("REDUCE"),

--- a/test/abap/statements/move.ts
+++ b/test/abap/statements/move.ts
@@ -105,6 +105,14 @@ const tests = [
   "  NEXT x = |{ x } { wa-matnr alpha = out }, | ).",
 
   "lv_str = | { zif_bar=>and ALIGN = RIGHT WIDTH = 5 } |.",
+
+  `DATA(foo) = REDUCE i( INIT s TYPE i FOR i = 1 UNTIL i > 10 NEXT s = s + i ).`,
+
+  `gp_amount_sp = REDUCE #( 
+    INIT x TYPE vbrk-netwr
+    FOR <i> IN invoices
+    WHERE ( vtweg = '20' )
+    NEXT x = x + <i>-kwert ).`,
 ];
 
 statementType(tests, "MOVE", Statements.Move);


### PR DESCRIPTION
- closes #747

Note: Currently, the `InlineFieldDefinition` works similar to a data definition, even though the variable should only be available in the scope of the move operation. Create a new issue for this?

Example:

```abap
DATA(foo) = REDUCE i( INIT s TYPE i FOR i = 1 UNTIL i > 10 NEXT s = s + i ).
" should give an error
s = 2.
```