### PR TITLE
Naming Rules: Patternkind to "Required" when "undefined"

### DIFF
--- a/src/rules/naming/class_attribute_names.ts
+++ b/src/rules/naming/class_attribute_names.ts
@@ -42,7 +42,9 @@ export class ClassAttributeNames implements IRule {
 
   public run(obj: IObject, reg: Registry): Issue[] {
     let attr: Attributes | undefined = undefined;
-
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
 // todo, consider local classes(PROG, FUGR, CLAS)
 
     if (obj instanceof Class) {

--- a/src/rules/naming/local_class_naming.ts
+++ b/src/rules/naming/local_class_naming.ts
@@ -38,6 +38,9 @@ export class LocalClassNaming extends ABAPRule {
 
   public runParsed(file: ABAPFile): Issue[] {
     const issues: Issue[] = [];
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
 
     for (const classDef of file.getClassDefinitions()) {
       if (classDef.isGlobal()) {

--- a/src/rules/naming/local_variable_names.ts
+++ b/src/rules/naming/local_variable_names.ts
@@ -43,6 +43,9 @@ export class LocalVariableNames extends ABAPRule {
 
   public runParsed(file: ABAPFile): Issue[] {
     let ret: Issue[] = [];
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
     const stru = file.getStructure();
 
     if (stru === undefined) {

--- a/src/rules/naming/method_parameter_names.ts
+++ b/src/rules/naming/method_parameter_names.ts
@@ -47,6 +47,9 @@ export class MethodParameterNames implements IRule {
 
   public run(obj: IObject, reg: Registry): Issue[] {
     let ret: Issue[] = [];
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
 
     if (!(obj instanceof ABAPObject)) {
       return [];

--- a/src/rules/naming/object_naming.ts
+++ b/src/rules/naming/object_naming.ts
@@ -59,14 +59,15 @@ export class ObjectNaming implements IRule {
 
   public setConfig(conf: ObjectNamingConf) {
     this.conf = conf;
-    if (this.conf.patternKind === undefined) {
-      this.conf.patternKind = "required";
-    }
   }
 
   public run(obj: IObject, _reg: Registry): Issue[] {
     let message: string | undefined = undefined;
     let pattern: string = "";
+
+    if (this.conf.patternKind === undefined) {
+      this.conf.patternKind = "required";
+    }
 
     if (obj instanceof Objects.Class) {
       pattern = this.getConfig().clas;

--- a/test/rules/naming/class_attribute_names.ts
+++ b/test/rules/naming/class_attribute_names.ts
@@ -40,6 +40,10 @@ CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(0);
+
+    // defaults to "required"
+    config.patternKind = undefined;
+    expect(findIssues(abap, config).length).to.equal(1);
   });
 
   it("no issue", function () {
@@ -57,6 +61,10 @@ CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(1);
+
+    // defaults to "required"
+    config.patternKind = undefined;
+    expect(findIssues(abap, config).length).to.equal(0);
   });
 
   it("issue", function () {
@@ -74,6 +82,9 @@ CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(0);
+
+    config.patternKind = undefined;
+    expect(findIssues(abap, config).length).to.equal(1);
   });
 
   it("end position", function () {
@@ -94,6 +105,11 @@ CLASS zcl_foobar IMPLEMENTATION. ENDCLASS.`;
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(0);
+
+    config.patternKind = undefined;
+    const issuesFromUndefinedPattern = findIssues(abap, config);
+    expect(issuesFromUndefinedPattern.length).to.equal(1);
+    expect(issuesFromUndefinedPattern[0].getEnd().getCol()).to.equal(33);
   });
 
 });

--- a/test/rules/naming/local_class_naming.ts
+++ b/test/rules/naming/local_class_naming.ts
@@ -39,3 +39,7 @@ config.test = "^ltcl_.*$";
 config.exception = "^lcx_.*$";
 config.patternKind = "forbidden";
 testRule(forbiddenPatternTests, LocalClassNaming, config);
+
+const undefinedPatternKindconfig = new LocalClassNamingConf();
+undefinedPatternKindconfig.patternKind = undefined;
+testRule(requiredPatternTests, LocalClassNaming, undefinedPatternKindconfig);

--- a/test/rules/naming/local_variable_names.ts
+++ b/test/rules/naming/local_variable_names.ts
@@ -35,6 +35,9 @@ describe("Rule: local variable names (required pattern)", function () {
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(1);
+
+    config.patternKind = undefined;
+    expect(findIssues(abap, config).length).to.equal(0);
   });
 
   it("local variable without prefix, FORM", function () {
@@ -51,6 +54,9 @@ describe("Rule: local variable names (required pattern)", function () {
 
     config.patternKind = "forbidden";
     expect(findIssues(abap, config).length).to.equal(0);
+
+    config.patternKind = undefined;
+    expect(findIssues(abap, config).length).to.equal(1);
   });
 
   it("local variable without prefix inside METHOD", function () {


### PR DESCRIPTION
fixes #776 

the check and set to default is during "runtime" because the `patternKind` is not necessarily set with the setter-method. Not nice but should be a temporary workaround