### PR TITLE
Auto npm publish

### DIFF
--- a/.github/workflows/autotag-new-versions.yml
+++ b/.github/workflows/autotag-new-versions.yml
@@ -11,29 +11,39 @@ jobs:
   add-tag:
     name: Add a tag on new version
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.repository == 'abaplint/abaplint'
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1    
-      - name: Detect new version and publish a tag
-        if: github.ref == 'refs/heads/master' && github.repository == 'abaplint/abaplint'
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Detect version change
+        id: detect_version_change
+        run: |
+          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          LAST_TAG=${LAST_TAG#v}
+          CURRENT_VERSION=$(jq -r -c .version package.json)
+          echo "Last tag: ${LAST_TAG}, Current version: ${CURRENT_VERSION}"
+          if [ "${LAST_TAG}" = "${CURRENT_VERSION}" ]; then
+            echo "Version change was not detected, exiting..."
+          else
+            echo "Version change detected"
+            echo "::set-output name=VERSION_CHANGED::yes"
+            echo "::set-output name=NEW_VERSION::$CURRENT_VERSION"
+          fi
+      - name: Create new tag
+        if: success() && steps.detect_version_change.outputs.VERSION_CHANGED == 'yes'
         env:
           GITHUB_TOKEN: ${{ secrets.MY_TOKEN }}
         run: |
-          git --version
-          jq --version
-          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          LAST_TAG=${LAST_TAG#v}
-          CUR_VERSION=$(jq -r -c .version package.json)
-          echo "Last tag: ${LAST_TAG}, Current version: ${CUR_VERSION}"
-          [ "${LAST_TAG}" = "${CUR_VERSION}" ] && echo "Version change was not detected, exiting..." && exit 0
-          echo "Version change detected"
-          [ -n "${GITHUB_TOKEN}" ] || echo "GITHUB_TOKEN is undefined"
-          [ -n "${GITHUB_TOKEN}" ] || exit 1
+          if [ -z "${GITHUB_TOKEN}" ]; then
+            echo "GITHUB_TOKEN is undefined"
+            exit 1
+          fi
           AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
           API_ENDPOINT="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/refs"
-          API_REQUEST="{ \"ref\": \"refs/tags/v$CUR_VERSION\", \"sha\": \"$GITHUB_SHA\" }"
-          echo "api endpoint: $API_ENDPOINT"
-          echo "api request:  $API_REQUEST"
-          echo "Publishing a new tag ..."
-          curl -s -X POST $API_ENDPOINT -H "$AUTH_HEADER" -d "$API_REQUEST"
+          API_REQUEST="{ \"ref\": \"refs/tags/v${{ steps.detect_version_change.outputs.NEW_VERSION }}\", \"sha\": \"${GITHUB_SHA}\" }"
+          echo "Api endpoint: ${API_ENDPOINT}"
+          echo "Api request:  ${API_REQUEST}"
+          HTTP_CODE=$(curl -s -X POST "$API_ENDPOINT" -H "$AUTH_HEADER" -d "$API_REQUEST" -w "%{http_code}\n" -o /tmp/response.json)
+          echo "Http code:    ${HTTP_CODE}"
+          cat /tmp/response.json
+          [[ $HTTP_CODE == 2* ]]

--- a/.github/workflows/on-new-tag.yml
+++ b/.github/workflows/on-new-tag.yml
@@ -1,0 +1,29 @@
+name: On new version tag
+
+on:
+  push:
+    tags:
+      - v* # Version tags
+
+jobs:
+  npm-publish:
+    name: Publish NPM package
+    runs-on: ubuntu-latest
+    if: github.repository == 'abaplint/abaplint'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: Prepare
+        run: npm install
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NODE_AUTH_TOKEN is undefined"
+            exit 1
+          fi
+          npm publish --access public


### PR DESCRIPTION
So here is auto NPM publish workflow. Already tested on https://github.com/sbcgua/mockup-compiler-js

- requires NPM_TOKEN secret ( @larshp could you pls add ? )
- triggers on new tags starting with `v`
- minor improvements in autotagging
  - split into 2 steps for clarity
  - better curl error handling (appeared that status 4** does not return error to console, so additional analysis needed of `-f` flag. however `-f` flag does not the body with error message then ... well ... now both work)

@larshp In fact I'd make one more change. In this or in a separate PR. Issue: currently autotag is running on change of package.json. which makes sense. But ! What if the package.json changed together with other files and maybe test does not pass ! It should not be a new version until mistakes are fixed ! So in fact autotagging should trigger only after successful test pass. Thus in `main` workflow (like in mockup-compiler above). This is actually important imho. The question is just if to make this change in this PR or in another. 