### PR TITLE
local_variable_names: change logic for data-begin structures, check only first level

### DIFF
--- a/packages/core/src/rules/naming/local_variable_names.ts
+++ b/packages/core/src/rules/naming/local_variable_names.ts
@@ -34,7 +34,7 @@ export class LocalVariableNames extends ABAPRule {
   private getDescription(expected: string, actual: string): string {
     return this.conf.patternKind === "required" ?
       "Local variable name does not match pattern " + expected + ": " + actual :
-      "Local variable name must not match pattern " + expected + ": " + actual ;
+      "Local variable name must not match pattern " + expected + ": " + actual;
   }
 
   public getConfig() {
@@ -56,7 +56,7 @@ export class LocalVariableNames extends ABAPRule {
       return [];
     }
 
-// inside METHOD, FORM, FUNCTION MODULE
+    // inside METHOD, FORM, FUNCTION MODULE
     for (const node of stru.findAllStructures(Structures.Form)) {
       ret = ret.concat(this.checkLocals(node, file));
     }
@@ -73,8 +73,7 @@ export class LocalVariableNames extends ABAPRule {
   private checkLocals(structure: StructureNode, file: ABAPFile): Issue[] {
     let ret: Issue[] = [];
 
-// data, field symbols
-
+    // data, field symbols
     const data = structure.findAllStatements(Statements.Data);
     for (const dat of data) {
       const parent = structure.findParent(dat);
@@ -88,9 +87,12 @@ export class LocalVariableNames extends ABAPRule {
       }
     }
 
-    const datab = structure.findAllStatements(Statements.DataBegin);
-    for (const dat of datab) {
-      const found = dat.findFirstExpression(Expressions.NamespaceSimpleName);
+    // data structures, data begin of, first level
+    const dataStructures = structure.findAllStructures(Structures.Data);
+    for (const struc of dataStructures) {
+      // ignore nested DATA BEGIN
+      const stat = struc.findFirstStatement(Statements.DataBegin);
+      const found = stat?.findFirstExpression(Expressions.NamespaceSimpleName);
       if (found) {
         const token = found.getFirstToken();
         ret = ret.concat(this.checkName(token, file, this.conf.expectedData));
@@ -118,10 +120,7 @@ export class LocalVariableNames extends ABAPRule {
         ret = ret.concat(this.checkName(token, file, this.conf.expectedConstant));
       }
     }
-
-// todo: inline data, inline field symbols
-// todo: DATA BEGIN OF
-
+    // todo: inline data, inline field symbols
     return ret;
   }
 

--- a/packages/core/test/rules/naming/local_variable_names.ts
+++ b/packages/core/test/rules/naming/local_variable_names.ts
@@ -77,6 +77,98 @@ ENDCLASS.`;
     expect(findIssues(abap, config).length).to.equal(0);
   });
 
+  it("local nested structure with prefix inside METHOD", () => {
+    const abap = `
+    CLASS lcl_abapgit_object_ddlx DEFINITION.
+    PUBLIC SECTION.
+      METHODS clear_fields.
+  ENDCLASS.
+  
+  
+  CLASS lcl_abapgit_object_ddlx IMPLEMENTATION.
+  
+    METHOD clear_fields.
+  
+      DATA:
+        BEGIN OF ls_fields_to_clear,
+          BEGIN OF metadata,
+            created_at    TYPE c,
+            created_by    TYPE c,
+            changed_at    TYPE c,
+            changed_by    TYPE c,
+            responsible   TYPE c,
+            BEGIN OF package_ref,
+              name TYPE c,
+            END OF package_ref,
+            BEGIN OF container_ref,
+              package_name TYPE c,
+            END OF container_ref,
+            version       TYPE c,
+            master_system TYPE c,
+          END OF metadata,
+        END OF ls_fields_to_clear.
+  
+      CLEAR ls_fields_to_clear.
+  
+    ENDMETHOD.
+  ENDCLASS.`;
+
+    const config = new LocalVariableNamesConf();
+    config.expectedData = anyUpToThreeLetterPrefix;
+
+    config.patternKind = "required";
+    expect(findIssues(abap, config).length).to.equal(0);
+
+    config.patternKind = "forbidden";
+    expect(findIssues(abap, config).length).to.equal(1);
+  });
+
+  it("local nested structure without prefix inside METHOD", () => {
+    const abap = `
+    CLASS lcl_abapgit_object_ddlx DEFINITION.
+    PUBLIC SECTION.
+      METHODS clear_fields.
+  ENDCLASS.
+  
+  
+  CLASS lcl_abapgit_object_ddlx IMPLEMENTATION.
+  
+    METHOD clear_fields.
+  
+      DATA:
+        BEGIN OF fields_to_clear,
+          BEGIN OF metadata,
+            created_at    TYPE c,
+            created_by    TYPE c,
+            changed_at    TYPE c,
+            changed_by    TYPE c,
+            responsible   TYPE c,
+            BEGIN OF package_ref,
+              name TYPE c,
+            END OF package_ref,
+            BEGIN OF container_ref,
+              package_name TYPE c,
+            END OF container_ref,
+            version       TYPE c,
+            master_system TYPE c,
+          END OF metadata,
+        END OF fields_to_clear.
+  
+      CLEAR ls_fields_to_clear.
+  
+    ENDMETHOD.
+  ENDCLASS.`;
+
+    const config = new LocalVariableNamesConf();
+    config.expectedData = anyUpToThreeLetterPrefix;
+
+    config.patternKind = "required";
+    expect(findIssues(abap, config).length).to.equal(1);
+
+    config.patternKind = "forbidden";
+    expect(findIssues(abap, config).length).to.equal(0);
+  });
+
   it("local variable without prefix inside Function Module", () => {
     const abap = `
 FUNCTION foo.


### PR DESCRIPTION
resolves #868 

logic changed for data-begin: only check data structures with depth 1 (in relation to method/form etc)