### PR TITLE
expose pretty printer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ import {IRegistry} from "./_iregistry";
 import {IFile} from "./files/_ifile";
 import {Position} from "./position";
 import {AbstractFile} from "./files/_abstract_file";
-import { PrettyPrinter } from "./pretty_printer/pretty_printer";
+import {PrettyPrinter} from "./pretty_printer/pretty_printer";
 
 // do not include this file from anywhere within abaplint
 
@@ -44,4 +44,4 @@ export {MemoryFile, Issue, Config, Version,
   AbstractType, TypedIdentifier, BasicTypes, ScopeType, INode, Token,
   IDependency, AbstractFile, SpaghettiScopeNode,
   Tokens, ABAPObject, SyntaxLogic, SpaghettiScope, IdentifierMeta,
-  ABAPFile, CurrentScope, IRegistry, Position,PrettyPrinter};
+  ABAPFile, CurrentScope, IRegistry, Position, PrettyPrinter};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ import {IRegistry} from "./_iregistry";
 import {IFile} from "./files/_ifile";
 import {Position} from "./position";
 import {AbstractFile} from "./files/_abstract_file";
+import { PrettyPrinter } from "./pretty_printer/pretty_printer";
 
 // do not include this file from anywhere within abaplint
 
@@ -43,4 +44,4 @@ export {MemoryFile, Issue, Config, Version,
   AbstractType, TypedIdentifier, BasicTypes, ScopeType, INode, Token,
   IDependency, AbstractFile, SpaghettiScopeNode,
   Tokens, ABAPObject, SyntaxLogic, SpaghettiScope, IdentifierMeta,
-  ABAPFile, CurrentScope, IRegistry, Position};
+  ABAPFile, CurrentScope, IRegistry, Position,PrettyPrinter};


### PR DESCRIPTION
Looks like this will work for abappretty:
```typescript
import { PrettyPrinter } from "@abaplint/core/build/src/pretty_printer/pretty_printer"
```
but relies too much on internal structure