### PR TITLE
ABAPObject type guard

### DIFF
--- a/packages/core/src/objects/_abap_object.ts
+++ b/packages/core/src/objects/_abap_object.ts
@@ -7,6 +7,7 @@ import {IClassImplementation} from "../abap/types/_class_implementation";
 import {IObject} from "./_iobject";
 import {Version} from "../version";
 
+const tag = Symbol("ABAPObject");
 export interface ITextElement {
   key: string;
   text: string;
@@ -14,10 +15,17 @@ export interface ITextElement {
 
 export abstract class ABAPObject extends AbstractObject {
   private parsed: readonly ABAPFile[];
+  private [tag] = true;
 
   public constructor(name: string) {
     super(name);
     this.parsed = [];
+  }
+
+  public static is(x:any):x is ABAPObject // silly overload to remove unused warning
+  // eslint-disable-next-line no-dupe-class-members
+  public static is(x:ABAPObject):x is ABAPObject{
+    return !!x?.[tag];
   }
 
   public parse(version: Version, globalMacros: readonly string[] | undefined): IObject {

--- a/packages/core/src/objects/_abap_object.ts
+++ b/packages/core/src/objects/_abap_object.ts
@@ -7,7 +7,6 @@ import {IClassImplementation} from "../abap/types/_class_implementation";
 import {IObject} from "./_iobject";
 import {Version} from "../version";
 
-const tag = Symbol("ABAPObject");
 export interface ITextElement {
   key: string;
   text: string;
@@ -15,17 +14,14 @@ export interface ITextElement {
 
 export abstract class ABAPObject extends AbstractObject {
   private parsed: readonly ABAPFile[];
-  private [tag] = true;
 
   public constructor(name: string) {
     super(name);
     this.parsed = [];
   }
 
-  public static is(x:any):x is ABAPObject // silly overload to remove unused warning
-  // eslint-disable-next-line no-dupe-class-members
-  public static is(x:ABAPObject):x is ABAPObject{
-    return !!x?.[tag];
+  public static is(x:any):x is ABAPObject{
+    return !!x && x instanceof ABAPObject;
   }
 
   public parse(version: Version, globalMacros: readonly string[] | undefined): IObject {

--- a/packages/core/test/get_abap.ts
+++ b/packages/core/test/get_abap.ts
@@ -2,5 +2,5 @@ import {IRegistry} from "../src/_iregistry";
 import {ABAPObject} from "../src/objects/_abap_object";
 
 export function getABAPObjects(reg: IRegistry): ABAPObject[] {
-  return reg.getObjects().filter((obj) => { return obj instanceof ABAPObject; }) as ABAPObject[];
+  return reg.getObjects().filter(ABAPObject.is);
 }


### PR DESCRIPTION
Not that useful, but I find it cleaner.

This would have worked fine for the main class, but the symbol based one works for subclasses too
```typescript
  public static is(x:any):x is ABAPObject{
    return o instanceof ABAPObject;
  }
```
PS: this also worked fine, but leaving an unused error for [tag]. Lines 25 and 26 was added to make linters happy
```typescript
  public static is(x:any):x is ABAPObject{
    return !!x?.[tag];
  }
```

Could also have done this, but ignores any type error on that line, not only the unused variable one, but ignores any TS error for that line:

```typescript
  // @ts-ignore
  private [tag] = true;

  public static is(x:any):x is ABAPObject{
    return !!x?.[tag];
  }
```
