### PR TITLE
Double space: Change reported position

### DIFF
--- a/packages/core/test/rules/whitespace/double_space.ts
+++ b/packages/core/test/rules/whitespace/double_space.ts
@@ -19,6 +19,7 @@ const tests = [
   {abap: "call(  \"comment\n).", cnt: 0},
   {abap: "foo = |  )|.", cnt: 0},
   {abap: "call( |hello| ).", cnt: 0},
+  {abap: "call(  ).", cnt: 1}, // call with empty parameters should only report once
   {abap: "call( |moo {\nvar }bar| ).", cnt: 0},
   {abap: "CLASS zsdfsdf DEFINITION PUBLIC  ABSTRACT FINAL CREATE PUBLIC.", cnt: 1},
   {abap: "CLASS-METHODS class_includes RETURNING VALUE(rt_programs)     TYPE scit_program.", cnt: 0},


### PR DESCRIPTION
change reporting from token to specific position

also:
- remove workarounds as referenced issue is closed
- add check for empty space between parentheses, one reporting


closes #820, closes #735, closes #705

Now:
![image](https://user-images.githubusercontent.com/27279305/82798894-7a66a480-9e79-11ea-9cd8-f80a35e6397e.png)

With these changes:

![image](https://user-images.githubusercontent.com/27279305/82798945-881c2a00-9e79-11ea-8feb-daff1880f532.png)
