### PR TITLE
preferred_compare_operator: quick fix

### DIFF
--- a/packages/core/src/rules/preferred_compare_operator.ts
+++ b/packages/core/src/rules/preferred_compare_operator.ts
@@ -68,6 +68,13 @@ export class PreferredCompareOperator extends ABAPRule {
       this.operatorMapping.set("GT", ">");
       this.operatorMapping.set("LT", "<");
       this.operatorMapping.set("LE", "<=");
+
+      this.operatorMapping.set("=", "EQ");
+      this.operatorMapping.set("<>", "NE");
+      this.operatorMapping.set(">=", "GE");
+      this.operatorMapping.set(">", "GT");
+      this.operatorMapping.set("<", "LT");
+      this.operatorMapping.set("<=", "LE");
     }
   }
 

--- a/packages/core/src/rules/preferred_compare_operator.ts
+++ b/packages/core/src/rules/preferred_compare_operator.ts
@@ -3,6 +3,8 @@ import {Issue} from "../issue";
 import {ABAPRule} from "./_abap_rule";
 import {ABAPFile} from "../files";
 import {BasicRuleConfig} from "./_basic_rule_config";
+import {EditHelper} from "../edit_helper";
+import {Token} from "../abap/1_lexer/tokens/_token";
 
 export class PreferredCompareOperatorConf extends BasicRuleConfig {
   /** Operators which are not allowed */
@@ -12,6 +14,8 @@ export class PreferredCompareOperatorConf extends BasicRuleConfig {
 export class PreferredCompareOperator extends ABAPRule {
 
   private conf = new PreferredCompareOperatorConf();
+
+  private readonly operatorMapping: Map<string, string> = new Map<string, string>();
 
   public getMetadata() {
     return {
@@ -26,7 +30,16 @@ export class PreferredCompareOperator extends ABAPRule {
     return "Compare operator \"" + operator + "\" not preferred";
   }
 
+  public getConfig() {
+    return this.conf;
+  }
+
+  public setConfig(conf: PreferredCompareOperatorConf) {
+    this.conf = conf;
+  }
+
   public runParsed(file: ABAPFile) {
+    this.buildMapping();
     const issues: Issue[] = [];
 
     const struc = file.getStructure();
@@ -39,21 +52,38 @@ export class PreferredCompareOperator extends ABAPRule {
     for (const op of operators) {
       const token = op.getLastToken();
       if (this.conf.badOperators.indexOf(token.getStr()) >= 0) {
-        const message = this.getDescription(token.getStr());
-        const issue = Issue.atToken(file, token, message, this.getMetadata().key);
-        issues.push(issue);
+        issues.push(this.createIssue(token, file));
       }
     }
 
     return issues;
   }
 
-  public getConfig() {
-    return this.conf;
+  private buildMapping() {
+    if (this.operatorMapping.size === 0) {
+      this.operatorMapping.set("EQ", "=");
+      this.operatorMapping.set("><", "<>");
+      this.operatorMapping.set("NE", "<>");
+      this.operatorMapping.set("GE", ">=");
+      this.operatorMapping.set("GT", ">");
+      this.operatorMapping.set("LT", "<");
+      this.operatorMapping.set("LE", "<=");
+    }
   }
 
-  public setConfig(conf: PreferredCompareOperatorConf) {
-    this.conf = conf;
+  private createIssue(token: Token, file: ABAPFile): Issue {
+    const message = this.getDescription(token.getStr());
+    const replacementToken = this.operatorMapping?.get(token.getStr());
+    // values in badOperators can be entered by the user and may not necessarily be actual operators
+    if (replacementToken) {
+      const fix = EditHelper.replaceRange(file, token.getStart(), token.getEnd(), replacementToken);
+      const issue = Issue.atToken(file, token, message, this.getMetadata().key, fix);
+      return issue;
+    }
+    else {
+      const issue = Issue.atToken(file, token, message, this.getMetadata().key);
+      return issue;
+    }
   }
 
 }

--- a/packages/core/test/rules/preferred_compare_operator.ts
+++ b/packages/core/test/rules/preferred_compare_operator.ts
@@ -1,4 +1,4 @@
-import {PreferredCompareOperator} from "../../src/rules/preferred_compare_operator";
+import {PreferredCompareOperator, PreferredCompareOperatorConf} from "../../src/rules/preferred_compare_operator";
 import {testRule, testRuleFix} from "./_utils";
 
 const tests = [
@@ -11,8 +11,6 @@ const tests = [
 
 testRule(tests, PreferredCompareOperator);
 
-
-
 const fixTests = [
   {input: "IF foo EQ bar. ENDIF.", output: "IF foo = bar. ENDIF."},
   {input: "IF foo NE bar. ENDIF.", output: "IF foo <> bar. ENDIF."},
@@ -24,3 +22,16 @@ const fixTests = [
   {input: "SELECT * FROM foo INTO TABLE bar WHERE moo EQ boo.", output: "SELECT * FROM foo INTO TABLE bar WHERE moo = boo."},
 ];
 testRuleFix(fixTests, PreferredCompareOperator);
+
+const letterConfig = new PreferredCompareOperatorConf();
+letterConfig.badOperators = ["=","<>","<=","<",">=",">"];
+const fixTestsLetters = [
+  {output: "IF foo EQ bar. ENDIF.", input: "IF foo = bar. ENDIF."},
+  {output: "IF foo NE bar. ENDIF.", input: "IF foo <> bar. ENDIF."},
+  {output: "IF foo GT bar. ENDIF.", input: "IF foo > bar. ENDIF."},
+  {output: "IF foo GE bar. ENDIF.", input: "IF foo >= bar. ENDIF."},
+  {output: "IF foo LE bar. ENDIF.", input: "IF foo <= bar. ENDIF."},
+  {output: "IF foo LT bar. ENDIF.", input: "IF foo < bar. ENDIF."},
+  {output: "SELECT * FROM foo INTO TABLE bar WHERE moo EQ boo.", input: "SELECT * FROM foo INTO TABLE bar WHERE moo = boo."},
+];
+testRuleFix(fixTestsLetters, PreferredCompareOperator, letterConfig);

--- a/packages/core/test/rules/preferred_compare_operator.ts
+++ b/packages/core/test/rules/preferred_compare_operator.ts
@@ -1,5 +1,5 @@
 import {PreferredCompareOperator} from "../../src/rules/preferred_compare_operator";
-import {testRule} from "./_utils";
+import {testRule, testRuleFix} from "./_utils";
 
 const tests = [
   {abap: "parser error", cnt: 0},
@@ -10,3 +10,17 @@ const tests = [
 ];
 
 testRule(tests, PreferredCompareOperator);
+
+
+
+const fixTests = [
+  {input: "IF foo EQ bar. ENDIF.", output: "IF foo = bar. ENDIF."},
+  {input: "IF foo NE bar. ENDIF.", output: "IF foo <> bar. ENDIF."},
+  {input: "IF foo >< bar. ENDIF.", output: "IF foo <> bar. ENDIF."},
+  {input: "IF foo GT bar. ENDIF.", output: "IF foo > bar. ENDIF."},
+  {input: "IF foo GE bar. ENDIF.", output: "IF foo >= bar. ENDIF."},
+  {input: "IF foo LE bar. ENDIF.", output: "IF foo <= bar. ENDIF."},
+  {input: "IF foo LT bar. ENDIF.", output: "IF foo < bar. ENDIF."},
+  {input: "SELECT * FROM foo INTO TABLE bar WHERE moo EQ boo.", output: "SELECT * FROM foo INTO TABLE bar WHERE moo = boo."},
+];
+testRuleFix(fixTests, PreferredCompareOperator);


### PR DESCRIPTION
Problem: user can enter `badOperators` freely - how to specify the operators that are replacements?
Currently only two letter operators and `><` are quick fixable.
What if user puts in contradictory operators, e.g. `EQ` and `=`?