### PR TITLE
begin_end_names: add quick fix

### DIFF
--- a/packages/core/src/rules/begin_end_names.ts
+++ b/packages/core/src/rules/begin_end_names.ts
@@ -9,6 +9,7 @@ import {StructureNode} from "../abap/nodes";
 import {IStructure} from "../abap/3_structures/structures/_structure";
 import {IStatement} from "../abap/2_statements/statements/_statement";
 import {RuleTag} from "./_irule";
+import {EditHelper} from "../edit_helper";
 
 export class BeginEndNamesConf extends BasicRuleConfig {
 }
@@ -20,7 +21,7 @@ export class BeginEndNames extends ABAPRule {
     return {
       key: "begin_end_names",
       title: "Check BEGIN END names",
-      quickfix: false,
+      quickfix: true,
       shortDescription: `Check BEGIN OF and END OF names match`,
       tags: [RuleTag.Syntax],
     };
@@ -70,7 +71,8 @@ export class BeginEndNames extends ABAPRule {
       const last = end.getFirstToken();
 
       if (first.getStr().toUpperCase() !== last.getStr().toUpperCase()) {
-        const issue = Issue.atToken(file, first, this.getMessage(), this.getMetadata().key);
+        const fix = EditHelper.replaceRange(file, last.getStart(), last.getEnd(), first.getStr());
+        const issue = Issue.atToken(file, first, this.getMessage(), this.getMetadata().key, fix);
         output.push(issue);
       }
 

--- a/packages/core/test/rules/begin_end_names.ts
+++ b/packages/core/test/rules/begin_end_names.ts
@@ -1,5 +1,5 @@
 import {BeginEndNames} from "../../src/rules/begin_end_names";
-import {testRule} from "./_utils";
+import {testRule, testRuleFix} from "./_utils";
 
 const tests = [
   {abap: "parser error", cnt: 0},
@@ -45,3 +45,26 @@ const tests = [
 ];
 
 testRule(tests, BeginEndNames);
+
+const fixTests = [
+  {
+    input: "TYPES: BEGIN OF moo, dsf TYPE string, END OF bar.",
+    output: "TYPES: BEGIN OF moo, dsf TYPE string, END OF moo.",
+  },
+  {
+    input: "TYPES: BEGIN OF ENUM moo, blah, END OF ENUM bar.",
+    output: "TYPES: BEGIN OF ENUM moo, blah, END OF ENUM moo.",
+  },
+  // difference in inner type
+  {
+    input: "DATA: BEGIN OF foo, BEGIN OF bar2, f TYPE string, END OF bar1, END OF foo.",
+    output: "DATA: BEGIN OF foo, BEGIN OF bar2, f TYPE string, END OF bar2, END OF foo.",
+  },
+  // difference in outer type
+  {
+    input: "DATA: BEGIN OF foo, BEGIN OF bar2, f TYPE string, END OF bar2, END OF fooaaa.",
+    output: "DATA: BEGIN OF foo, BEGIN OF bar2, f TYPE string, END OF bar2, END OF foo.",
+  },
+];
+
+testRuleFix(fixTests, BeginEndNames);


### PR DESCRIPTION
change `END OF` identifier to be the same as in `BEGIN OF`