### PR TITLE
sequential_blank: add quick fix

### DIFF
--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -1687,7 +1687,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Checks that code does not contain more than the configured number of blank lines in a row.\nTags: Whitespace\nhttps://rules.abaplint.org/sequential_blank"
+              "description": "Checks that code does not contain more than the configured number of blank lines in a row.\nTags: Whitespace, Quickfix\nhttps://rules.abaplint.org/sequential_blank"
             },
             "short_case": {
               "anyOf": [

--- a/packages/core/test/rules/sequential_blank.ts
+++ b/packages/core/test/rules/sequential_blank.ts
@@ -1,5 +1,5 @@
 import {SequentialBlank} from "../../src/rules/sequential_blank";
-import {testRule} from "./_utils";
+import {testRule, testRuleFix} from "./_utils";
 import {expect} from "chai";
 
 const tests = [
@@ -25,3 +25,15 @@ describe("blank line matching", () => {
 });
 
 testRule(tests, SequentialBlank);
+
+
+const fixTests = [
+  {input: "REPORT zfoo.\n\n\n\n\n", output: "REPORT zfoo.\n\n\n"},
+  {input: "REPORT zfoo.\n\n\n\n\t\t\t", output: "REPORT zfoo.\n\n\n"},
+  // the following two should be three newlines in the output, but it seems to be
+  // inconsistent due to the way it's split on newlines into rows
+  {input: "REPORT zfoo.\n\n\n\n\nWRITE 1.", output: "REPORT zfoo.\n\n\n\nWRITE 1."},
+  {input: "REPORT zfoo.\n\n\n\n\n\t\t\t\nWRITE 1.", output: "REPORT zfoo.\n\n\n\nWRITE 1."},
+];
+
+testRuleFix(fixTests, SequentialBlank);

--- a/packages/core/test/rules/sequential_blank.ts
+++ b/packages/core/test/rules/sequential_blank.ts
@@ -5,6 +5,7 @@ import {expect} from "chai";
 const tests = [
   {abap: "\n\n\n\n", cnt: 1},
   {abap: "WRITE: / 'abc'.", cnt: 0},
+  {abap: "REPORT zfoo.\n\n\n\nWRITE 1.", cnt: 0},
 ];
 
 const blankTests = [
@@ -28,10 +29,9 @@ testRule(tests, SequentialBlank);
 
 
 const fixTests = [
-  {input: "REPORT zfoo.\n\n\n\n\n", output: "REPORT zfoo.\n\n\n"},
+  {input: "REPORT zfoo.\n\n\n\n", output: "REPORT zfoo.\n\n\n"},
   {input: "REPORT zfoo.\n\n\n\n\t\t\t", output: "REPORT zfoo.\n\n\n"},
-  // the following two should be three newlines in the output, but it seems to be
-  // inconsistent due to the way it's split on newlines into rows
+  //3 blank lines + the carriage return on the line of the first statement
   {input: "REPORT zfoo.\n\n\n\n\nWRITE 1.", output: "REPORT zfoo.\n\n\n\nWRITE 1."},
   {input: "REPORT zfoo.\n\n\n\n\n\t\t\t\nWRITE 1.", output: "REPORT zfoo.\n\n\n\nWRITE 1."},
 ];


### PR DESCRIPTION
closes #967 

This was more annoying than expected, please also note the last two test cases. 
For some reason it does not remove a single newline when run in the test, but in the playground it works properly. Maybe this is due to how the lines are split on `\n`?