### PR TITLE
Update EXPORT/IMPORT DATABASE to recognize db table

### DIFF
--- a/packages/core/src/abap/2_statements/statements/export.ts
+++ b/packages/core/src/abap/2_statements/statements/export.ts
@@ -1,35 +1,30 @@
 import {IStatement} from "./_statement";
-import {str, seq, alt, altPrio, opt, per, plus} from "../combi";
-import {Target, Source, Field, Dynamic, ParameterS, FieldSub} from "../expressions";
+import {str, seq, alt, altPrio, opt, per, plus, tok} from "../combi";
+import {ParenLeft, ParenRightW} from "../../1_lexer/tokens";
+import {Target, Source, Dynamic, ParameterS, FieldSub, SimpleName, NamespaceSimpleName} from "../expressions";
 import {IStatementRunnable} from "../statement_runnable";
 
 // todo, cloud, split?
 export class Export implements IStatement {
 
   public getMatcher(): IStatementRunnable {
-    const id = seq(str("ID"), new Source());
-
-    const db = seq(str("DATA BUFFER"), new Target());
-    const memory = seq(str("MEMORY ID"), new Source());
     const from = seq(str("FROM"), new Source());
-    const using = seq(str("USING"), new Source());
     const client = seq(str("CLIENT"), new Source());
+    const id = seq(str("ID"), new Source());
+    const using = seq(str("USING"), new Source());
+
+    const cluster = seq(new NamespaceSimpleName(),
+                        tok(ParenLeft),
+                        new SimpleName(),
+                        tok(ParenRightW));
+
+    const buffer = seq(str("DATA BUFFER"), new Target());
+    const memory = seq(str("MEMORY ID"), new Source());
     const table = seq(str("INTERNAL TABLE"), new Target());
+    const shared = seq(alt(str("SHARED MEMORY"), str("SHARED BUFFER")), cluster, per(from, client, id));
+    const database = seq(str("DATABASE"), cluster, per(from, client, id, using));
 
-    const shared = seq(alt(str("SHARED MEMORY"), str("SHARED BUFFER")),
-                       new Field(),
-                       str("("),
-                       new Field(),
-                       str(")"),
-                       str("ID"),
-                       new Source(),
-                       opt(from));
-
-    const database = seq(str("DATABASE"),
-                         new Source(),
-                         per(from, client, id, using));
-
-    const target = alt(db, memory, database, table, shared);
+    const target = alt(buffer, memory, database, table, shared);
 
     const source = alt(plus(altPrio(new ParameterS(), new FieldSub())),
                        new Dynamic());
@@ -37,13 +32,7 @@ export class Export implements IStatement {
     const compression = seq(str("COMPRESSION"), alt(str("ON"), str("OFF")));
     const hint = seq(str("CODE PAGE HINT"), new Source());
 
-    return seq(str("EXPORT"),
-               source,
-               opt(from),
-               str("TO"),
-               target,
-               opt(compression),
-               opt(hint));
+    return seq(str("EXPORT"), source, opt(from), str("TO"), target, opt(compression), opt(hint));
   }
 
 }

--- a/packages/core/src/abap/2_statements/statements/import.ts
+++ b/packages/core/src/abap/2_statements/statements/import.ts
@@ -1,39 +1,28 @@
 import {IStatement} from "./_statement";
-import {verNot, str, seq, opt, alt, per, plus} from "../combi";
-import {Target, Source, Dynamic, Field, ComponentChainSimple} from "../expressions";
+import {verNot, str, seq, opt, alt, per, plus, tok} from "../combi";
+import {ParenLeft, ParenRightW} from "../../1_lexer/tokens";
+import {Target, Source, Dynamic, ComponentChainSimple, SimpleName, NamespaceSimpleName} from "../expressions";
 import {Version} from "../../../version";
 import {IStatementRunnable} from "../statement_runnable";
 
 export class Import implements IStatement {
 
   public getMatcher(): IStatementRunnable {
-    const id = seq(str("ID"), new Source());
     const dto = seq(str("TO"), new Target());
     const client = seq(str("CLIENT"), new Source());
+    const id = seq(str("ID"), new Source());
+    const using = seq(str("USING"), new Source());
 
-    const options = per(str("ACCEPTING PADDING"),
-                        str("IGNORING CONVERSION ERRORS"),
-                        str("IN CHAR-TO-HEX MODE"),
-                        str("IGNORING STRUCTURE BOUNDARIES"),
-                        str("ACCEPTING TRUNCATION"));
-
-    const shared = seq(str("SHARED"),
-                       alt(str("MEMORY"), str("BUFFER")),
-                       new Field(),
-                       str("("),
-                       new Field(),
-                       str(")"),
-                       id,
-                       opt(dto));
+    const cluster = seq(new NamespaceSimpleName(),
+                        tok(ParenLeft),
+                        new SimpleName(),
+                        tok(ParenRightW));
 
     const buffer = seq(str("DATA BUFFER"), new Source());
     const memory = seq(str("MEMORY ID"), new Source());
-    const using = seq(str("USING"), new Source());
     const table = seq(str("INTERNAL TABLE"), new Source());
-
-    const database = seq(str("DATABASE"),
-                         new Source(),
-                         per(dto, id, client, using));
+    const shared = seq(alt(str("SHARED MEMORY"), str("SHARED BUFFER")), cluster, per(dto, client, id));
+    const database = seq(str("DATABASE"), cluster, per(dto, client, id, using));
 
     const source = alt(buffer, memory, database, table, shared);
 
@@ -49,6 +38,16 @@ export class Import implements IStatement {
                        to,
                        new Dynamic(),
                        plus(new Target()));
+
+    const options = per(str("ACCEPTING PADDING"),
+                        str("IGNORING CONVERSION ERRORS"),
+                        str("IN CHAR-TO-HEX MODE"),
+                        str("IGNORING STRUCTURE BOUNDARIES"),
+                        str("ACCEPTING TRUNCATION"),
+                        seq(str("REPLACEMENT CHARACTER"), new Source()),
+                        seq(str("CODE PAGE INTO"), new Source()),
+                        seq(str("ENDIAN INTO"), new Source())
+                        );
 
     const ret = seq(str("IMPORT"), target, str("FROM"), source, opt(options));
 

--- a/packages/core/test/abap/statements/export.ts
+++ b/packages/core/test/abap/statements/export.ts
@@ -21,6 +21,7 @@ const tests = [
   "EXPORT foo-bar moo-boo TO MEMORY ID 'ABCD'.",
   "EXPORT field = field TO SHARED BUFFER INDX(AB) ID 'FOO' FROM var.",
 //  "EXPORT <wa> = <wa> TO DATABASE foobar(aa) ID me->name FROM l_wa.",
+  "EXPORT data = lt_data TO DATABASE indx(zr) FROM lv_indx CLIENT lv_clnt ID lc_id."
 ];
 
 statementType(tests, "EXPORT", Statements.Export);

--- a/packages/core/test/abap/statements/import.ts
+++ b/packages/core/test/abap/statements/import.ts
@@ -23,6 +23,7 @@ const tests = [
   "IMPORT line TO converted FROM DATABASE foob(aa) ID id USING source IGNORING CONVERSION ERRORS.",
   "IMPORT foo-bar = foo-bar FROM DATABASE datab(aa) ID lv_id USING lv_read.",
   "IMPORT field = field FROM SHARED BUFFER INDX(AA) ID 'FOO' TO var.",
+  "IMPORT data = lt_data FROM DATABASE indx(zr) TO lv_data CLIENT lv_clnt ID lc_id."
 ];
 
 statementType(tests, "IMPORT", Statements.Import);

--- a/packages/core/test/abap/syntax/syntax.ts
+++ b/packages/core/test/abap/syntax/syntax.ts
@@ -1885,6 +1885,30 @@ DATA(item) = lr_log->not_found.`;
     expect(issues.length).to.equals(1);
   });
 
+  it("data reference, component not found in structure", () => {
+    const abap = `TYPES: BEGIN OF ty_log,
+  item TYPE i,
+END OF ty_log.
+DATA lr_log TYPE REF TO ty_log.
+DATA(item) = lr_log->not_found.`;
+    const issues = runProgram(abap);
+    expect(issues.length).to.equals(1);
+  });
+
+  it("EXPORT DATABASE", () => {
+    const abap = `DATA gt_data TYPE TABLE OF string.
+EXPORT data = gt_data TO DATABASE indx(zr) ID 'TEST'.`;
+    const issues = runProgram(abap);
+    expect(issues.length).to.equals(0);
+  });
+
+  it("IMPORT DATABASE", () => {
+    const abap = `DATA gt_data TYPE TABLE OF string.
+IMPORT data = gt_data FROM DATABASE indx(zr) ID 'TEST'.`;
+    const issues = runProgram(abap);
+    expect(issues.length).to.equals(0);
+  });
+
 // todo, static method cannot access instance attributes
 // todo, can a private method access protected attributes?
 // todo, readonly fields(constants + enums + attributes flagged read-only)

--- a/packages/core/test/abap/syntax/syntax.ts
+++ b/packages/core/test/abap/syntax/syntax.ts
@@ -1885,16 +1885,6 @@ DATA(item) = lr_log->not_found.`;
     expect(issues.length).to.equals(1);
   });
 
-  it("data reference, component not found in structure", () => {
-    const abap = `TYPES: BEGIN OF ty_log,
-  item TYPE i,
-END OF ty_log.
-DATA lr_log TYPE REF TO ty_log.
-DATA(item) = lr_log->not_found.`;
-    const issues = runProgram(abap);
-    expect(issues.length).to.equals(1);
-  });
-
   it("EXPORT DATABASE", () => {
     const abap = `DATA gt_data TYPE TABLE OF string.
 EXPORT data = gt_data TO DATABASE indx(zr) ID 'TEST'.`;


### PR DESCRIPTION
Fixes detection of cluster tables for EXPORT/IMPORT statements (DELETE FROM DATABASE works with cluster tables and served as a template).

Reproduce:

CONSTANTS gc_test TYPE c LENGTH 10 VALUE 'TEST'.
DATA gt_data TYPE TABLE OF string.

" works:
DELETE FROM DATABASE indx(zr) ID gc_test.
" "indx" not found(check_syntax):
EXPORT data = gt_data TO DATABASE indx(zr) ID gc_test.
" "indx" not found(check_syntax):
IMPORT data = gt_data FROM DATABASE indx(zr) ID gc_test.

I added a couple tests although there were already some similar ones.
