### PR TITLE
Add LINE OF/REF TO for form parameters

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/form_param_type.ts
+++ b/packages/core/src/abap/2_statements/expressions/form_param_type.ts
@@ -15,7 +15,9 @@ export class FormParamType extends Expression {
                     new TypeName(),
                     opt(def));
 
-    const like = seq(str("LIKE"), optPrio(str("LINE OF")), new FieldChain(), opt(new TableBody()));
+    const like = seq(str("LIKE"), optPrio(alt(str("REF TO"),str("LINE OF"))), 
+                                  new FieldChain(), 
+                                  opt(new TableBody()));
 
     return alt(seq(str("TYPE"), altPrio(tabseq, ret)), like);
   }

--- a/packages/core/src/abap/2_statements/expressions/form_param_type.ts
+++ b/packages/core/src/abap/2_statements/expressions/form_param_type.ts
@@ -11,11 +11,11 @@ export class FormParamType extends Expression {
 
     const tabseq = seq(table, optPrio(seq(str("OF"), new TypeName())));
 
-    const ret = seq(optPrio(str("REF TO")),
+    const ret = seq(optPrio(alt(str("REF TO"),str("LINE OF"))),
                     new TypeName(),
                     opt(def));
 
-    const like = seq(str("LIKE"), new FieldChain(), opt(new TableBody()));
+    const like = seq(str("LIKE"), optPrio(str("LINE OF")), new FieldChain(), opt(new TableBody()));
 
     return alt(seq(str("TYPE"), altPrio(tabseq, ret)), like);
   }

--- a/packages/core/test/abap/statements/form.ts
+++ b/packages/core/test/abap/statements/form.ts
@@ -143,6 +143,11 @@ const tests = [
 
   "FORM formname USING $var $lang$sdf$ $lang$sdf.",
 
+  "FORM foobar USING p_param LIKE LINE OF gt_foo.",
+  "FORM foobar USING p_param LIKE REF TO go_foo.",
+  "FORM foobar USING p_param TYPE LINE OF tt_foo.",
+  "FORM foobar USING p_param TYPE REF TO to_foo.",
+
 //  "FORM moo USING boo-vbeln bar-vbtyp.",
 ];
 


### PR DESCRIPTION
Closes https://github.com/abaplint/abaplint/issues/1021

Quick fix but it seems that FormParamType could be replaced by expression/Type:
https://help.sap.com/doc/abapdocu_754_index_htm/7.54/en-US/abapform_parameters.htm
