### PR TITLE
json5

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2122,7 +2122,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
             "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -2308,8 +2307,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
             "version": "0.5.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
         "typescript": "^3.9.6"
     },
     "dependencies": {
+        "json5": "^2.1.3",
         "vscode-languageserver-types": "^3.15.1",
         "xml-js": "^1.6.11"
     }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,7 @@ import {Version, defaultVersion} from "./version";
 import {ArtifactsRules} from "./artifacts_rules";
 import {IRule} from "./rules/_irule";
 import {IConfig, IGlobalConfig, ISyntaxSettings, IConfiguration} from "./_config";
+import * as JSON5 from "json5";
 
 // assumption: this class is immutable
 export class Config implements IConfiguration {
@@ -69,7 +70,7 @@ export class Config implements IConfiguration {
   }
 
   public constructor(json: string) {
-    this.config = JSON.parse(json);
+    this.config = JSON5.parse(json);
 
     if (this.config.global === undefined) {
       this.config.global = Config.getDefault().getGlobal();

--- a/packages/core/test/config.ts
+++ b/packages/core/test/config.ts
@@ -43,6 +43,20 @@ describe("Registry", () => {
     expect(conf.getEnabledRules().length).to.equal(2);
   });
 
+  it("should support JSON5 (comments, trailing comma)", () => {
+    const config = getConfig({
+      "7bit_ascii": true,
+      "check_comments": true,
+      "avoid_use": true,
+    });
+
+    const confString = JSON.stringify(config, null, 2)
+      .replace("\"check_comments\"", "//\"check_comments\"")
+      .replace("\"avoid_use\": true", "\"avoid_use\": true,");
+    const conf = new Config(confString);
+    expect(conf.getEnabledRules().length).to.equal(2);
+  });
+
   it("should not do anything bad if you have an old config, old behavior for false", () => {
     const config = getConfig({}) as any;
     config.global.applyUnspecifiedRules = false;


### PR DESCRIPTION
to #507
appeared to be a very simple one :)

Added json5 dep, parsing and UT. minimist is referred just in cli.js of json5, which is not then referred from index.js. Besides both json5 and minimist were already in deps of core (as deep deps). So I think it should be ok. 
But speaking about web test - how to run it ? I didn't find a script or a readme for that ?