### PR TITLE
Keyword rule ignore class boundary

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
         "postcompile": "sh scripts/version.sh",
         "pretest": "npm run compile",
         "test": "mocha",
+        "test:only": "npm run compile && mocha",
         "posttest": "npm run lint && npm run schema",
         "prepublishOnly": "rm -rf build && npm run test",
         "precoverage": "npm run compile",

--- a/packages/core/src/rules/keyword_case.ts
+++ b/packages/core/src/rules/keyword_case.ts
@@ -26,6 +26,8 @@ export class KeywordCaseConf extends BasicRuleConfig {
   public ignoreGlobalClassDefinition: boolean = false;
   public ignoreGlobalInterface: boolean = false;
   public ignoreFunctionModuleName: boolean = false;
+  // this ignores keywords in CLASS/ENDCLASS statements of a global class (and only in them, the rest is checked)
+  public ignoreGlobalClassBoundries: boolean = false;
 
   /** A list of keywords to be ignored */
   public ignoreKeywords: string[] = [];
@@ -72,6 +74,7 @@ export class KeywordCase extends ABAPRule {
   public runParsed(file: ABAPFile, obj: IObject) {
     const issues: Issue[] = [];
     let skip = false;
+    // let isGlobalClass = false;
 
     const ddic = new DDIC(this.reg);
 
@@ -89,6 +92,15 @@ export class KeywordCase extends ABAPRule {
         || statement.get() instanceof Comment) {
         continue;
       }
+
+      // if (this.conf.ignoreGlobalClassBoundries) {
+      //   if (statement.get() instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.Global)) {
+      //     isGlobalClass = true;
+      //     continue;
+      //   } else if (isGlobalClass === true && statement.get() instanceof Statements.EndClass) {
+      //     continue;
+      //   }
+      // }
 
       if (this.conf.ignoreGlobalClassDefinition) {
         if (statement.get() instanceof Statements.ClassDefinition

--- a/packages/core/src/rules/keyword_case.ts
+++ b/packages/core/src/rules/keyword_case.ts
@@ -27,7 +27,7 @@ export class KeywordCaseConf extends BasicRuleConfig {
   public ignoreGlobalInterface: boolean = false;
   public ignoreFunctionModuleName: boolean = false;
   // this ignores keywords in CLASS/ENDCLASS statements of a global class (and only in them, the rest is checked)
-  public ignoreGlobalClassBoundries: boolean = false;
+  public ignoreGlobalClassBoundaries: boolean = false;
 
   /** A list of keywords to be ignored */
   public ignoreKeywords: string[] = [];
@@ -74,7 +74,7 @@ export class KeywordCase extends ABAPRule {
   public runParsed(file: ABAPFile, obj: IObject) {
     const issues: Issue[] = [];
     let skip = false;
-    // let isGlobalClass = false;
+    let isGlobalClass = false;
 
     const ddic = new DDIC(this.reg);
 
@@ -93,14 +93,16 @@ export class KeywordCase extends ABAPRule {
         continue;
       }
 
-      // if (this.conf.ignoreGlobalClassBoundries) {
-      //   if (statement.get() instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.Global)) {
-      //     isGlobalClass = true;
-      //     continue;
-      //   } else if (isGlobalClass === true && statement.get() instanceof Statements.EndClass) {
-      //     continue;
-      //   }
-      // }
+      if (this.conf.ignoreGlobalClassBoundaries) {
+        const node = statement.get();
+        if (node instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.Global)) {
+          isGlobalClass = true;
+          continue;
+        } else if (isGlobalClass === true
+          && (node instanceof Statements.EndClass || node instanceof Statements.ClassImplementation)) {
+          continue;
+        }
+      }
 
       if (this.conf.ignoreGlobalClassDefinition) {
         if (statement.get() instanceof Statements.ClassDefinition

--- a/packages/core/test/rules/_utils.ts
+++ b/packages/core/test/rules/_utils.ts
@@ -15,12 +15,16 @@ export function runMulti(files: {filename: string, contents: string}[]): readonl
   return reg.parse().findIssues();
 }
 
-export function testRule(tests: {abap: string, cnt: number}[], rule: new () => IRule, config?: any, testTitle?: string) {
+export function testRule(tests: {abap: string, cnt: number, only?: boolean}[], rule: new () => IRule, config?: any, testTitle?: string) {
   const nrule = new rule();
   if (config) {
     nrule.setConfig(config);
   }
   testTitle = testTitle || `test ${nrule.getMetadata().key} rule`;
+  const hasOnly = tests.findIndex(t => t.only === true) > 0;
+  if (hasOnly) {
+    tests = tests.filter(t => t.only === true);
+  }
   describe(testTitle, function () {
     // note that timeout() only works inside function()
     this.timeout(200);

--- a/packages/core/test/rules/keyword_case.ts
+++ b/packages/core/test/rules/keyword_case.ts
@@ -136,7 +136,7 @@ testRule(tests5, KeywordCase, config5);
 const testLowerCaseGlobalClassSuite1 = [
   {
     abap: `
-      class zcl_my definition final.
+      class zcl_my definition final public.
         public section.
           methods x.
       endclass.
@@ -148,7 +148,7 @@ const testLowerCaseGlobalClassSuite1 = [
   },
   {
     abap: `
-      CLASS zcl_my definition FINAL.
+      CLASS zcl_my definition FINAL public.
         public section.
           methods x.
       ENDCLASS.
@@ -160,7 +160,7 @@ const testLowerCaseGlobalClassSuite1 = [
   },
   {
     abap: `
-      class zcl_my definition final.
+      class zcl_my definition final public.
         public section.
           METHODS x.
       endclass.
@@ -172,7 +172,7 @@ const testLowerCaseGlobalClassSuite1 = [
   },
   {
     abap: `
-      class zcl_my definition final.
+      class zcl_my definition final public.
         public section.
           methods x.
       endclass.
@@ -183,10 +183,17 @@ const testLowerCaseGlobalClassSuite1 = [
     cnt: 1,
   },
 ];
-const configLowerCaseGlobalClass1 = {...new KeywordCaseConf(), style: KeywordCaseStyle.Lower};
-testRule(testLowerCaseGlobalClassSuite1, KeywordCase, configLowerCaseGlobalClass1);
+const configLowerCaseGlobalClass1 = {
+  ...new KeywordCaseConf(),
+  style: KeywordCaseStyle.Lower,
+};
+testRule(testLowerCaseGlobalClassSuite1, KeywordCase, configLowerCaseGlobalClass1, "keywordCase: lower");
 
 // no errors in case 2 for suite 2
-const testLowerCaseGlobalClassSuite2 = testLowerCaseGlobalClassSuite1.map((c, idx) => idx === 1 ? {...c, cnd: 0} : c);
-const configLowerCaseGlobalClass2 = {...configLowerCaseGlobalClass1, ignoreGlobalClassBoundries: true};
-testRule(testLowerCaseGlobalClassSuite2, KeywordCase, configLowerCaseGlobalClass2);
+const testLowerCaseGlobalClassSuite2 = testLowerCaseGlobalClassSuite1.map((c, idx) => idx === 1 ? {...c, cnt: 0} : c);
+const configLowerCaseGlobalClass2 = {
+  ...new KeywordCaseConf(),
+  style: KeywordCaseStyle.Lower,
+  ignoreGlobalClassBoundaries: true,
+};
+testRule(testLowerCaseGlobalClassSuite2, KeywordCase, configLowerCaseGlobalClass2, "keywordCase: lower + ignore boundaries");

--- a/packages/core/test/rules/keyword_case.ts
+++ b/packages/core/test/rules/keyword_case.ts
@@ -130,3 +130,63 @@ testRule(tests5, KeywordCase, config5);
 // test inconsistent case in ignored keyword list
 config5.ignoreKeywords = ["texT", "WrItE"];
 testRule(tests5, KeywordCase, config5);
+
+// ************************
+
+const testLowerCaseGlobalClassSuite1 = [
+  {
+    abap: `
+      class zcl_my definition final.
+        public section.
+          methods x.
+      endclass.
+      class zcl_my implementation.
+        method x. endmethod.
+      endclass.
+      `,
+    cnt: 0,
+  },
+  {
+    abap: `
+      CLASS zcl_my definition FINAL.
+        public section.
+          methods x.
+      ENDCLASS.
+      CLASS zcl_my IMPLEMENTATION.
+        method x. endmethod.
+      ENDCLASS.
+      `,
+    cnt: 1,
+  },
+  {
+    abap: `
+      class zcl_my definition final.
+        public section.
+          METHODS x.
+      endclass.
+      class zcl_my implementation.
+        method x. endmethod.
+      endclass.
+      `,
+    cnt: 1,
+  },
+  {
+    abap: `
+      class zcl_my definition final.
+        public section.
+          methods x.
+      endclass.
+      class zcl_my implementation.
+        METHOD x. endmethod.
+      endclass.
+      `,
+    cnt: 1,
+  },
+];
+const configLowerCaseGlobalClass1 = {...new KeywordCaseConf(), style: KeywordCaseStyle.Lower};
+testRule(testLowerCaseGlobalClassSuite1, KeywordCase, configLowerCaseGlobalClass1);
+
+// no errors in case 2 for suite 2
+const testLowerCaseGlobalClassSuite2 = testLowerCaseGlobalClassSuite1.map((c, idx) => idx === 1 ? {...c, cnd: 0} : c);
+const configLowerCaseGlobalClass2 = {...configLowerCaseGlobalClass1, ignoreGlobalClassBoundries: true};
+testRule(testLowerCaseGlobalClassSuite2, KeywordCase, configLowerCaseGlobalClass2);


### PR DESCRIPTION
Adds `ignoreGlobalClassBoundaries` flag for `keyword_case` rule.

Case: keyword style set to lower_case

```abap
      CLASS zcl_my DEFINITION FINAL PUBLIC.
        public section.
          methods x.
      ENDCLASS.
      CLASS zcl_my IMPLEMENTATION.
        method x. endmethod.
      ENDCLASS.
```

The class/endclass statements are uppercased by SE80. Even if pretty print settings are set to lowercase. So should be a possiblity to ignore it.

while this should be caught properly
```abap
      CLASS zcl_my DEFINITION FINAL PUBLIC.
        public section.
          METHODS x. " <<<<<<
      ENDCLASS.

```

On the way:
- added `test:only` npm script
- added `only` flag to `testRule` util to temporary focus on specific test cases

P.S. sorry for some emotions, but am I the only one who find the current test flows inconvenient ? Or I just don't know the right way ? :))) does not meant to offend ... just spent a lot of time waiting for test execution and analyzing lots of output because could not use features like only and watch conveniently ... :) maybe I just don't know the right way for abaplint ... could be nice to have some description of devflows :)

