### PR TITLE
keyword_case ignoreGlobalClassBoundaries for interfaces

### DIFF
--- a/packages/core/src/rules/keyword_case.ts
+++ b/packages/core/src/rules/keyword_case.ts
@@ -76,6 +76,7 @@ export class KeywordCase extends ABAPRule {
     const issues: Issue[] = [];
     let skip = false;
     let isGlobalClass = false;
+    let isGlobalIf = false;
 
     const ddic = new DDIC(this.reg);
 
@@ -97,6 +98,12 @@ export class KeywordCase extends ABAPRule {
 
       if (this.conf.ignoreGlobalClassBoundaries) {
         const node = statement.get();
+        if (node instanceof Statements.Interface && statement.findFirstExpression(Expressions.ClassGlobal)) {
+          isGlobalIf = true;
+          continue;
+        } else if (isGlobalIf === true && node instanceof Statements.EndInterface) {
+          continue;
+        }
         if (node instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.ClassGlobal)) {
           isGlobalClass = true;
           continue;

--- a/packages/core/test/rules/keyword_case.ts
+++ b/packages/core/test/rules/keyword_case.ts
@@ -171,6 +171,14 @@ const testLowerCaseGlobalClassSuite1 = [
   },
   {
     abap: `
+      INTERFACE zif_my PUBLIC.
+        methods x.
+      ENDINTERFACE.
+      `,
+    cnt: 1,
+  },
+  {
+    abap: `
       class zcl_my definition final public.
         public section.
           METHODS x.
@@ -201,7 +209,13 @@ const configLowerCaseGlobalClass1 = {
 testRule(testLowerCaseGlobalClassSuite1, KeywordCase, configLowerCaseGlobalClass1, "keywordCase: lower");
 
 // no errors in case 2 for suite 2
-const testLowerCaseGlobalClassSuite2 = testLowerCaseGlobalClassSuite1.map((c, idx) => idx === 1 ? {...c, cnt: 0} : c);
+const testLowerCaseGlobalClassSuite2 = testLowerCaseGlobalClassSuite1.map((c, idx) => {
+  if (idx === 1 || idx === 2) { // Case 2 and 3
+    return {...c, cnt: 0}; // clear cnt ( = no error )
+  } else {
+    return c;
+  }
+});
 const configLowerCaseGlobalClass2 = {
   ...new KeywordCaseConf(),
   style: KeywordCaseStyle.Lower,


### PR DESCRIPTION
```abap
      INTERFACE zif_my PUBLIC.
        methods x.
      ENDINTERFACE.
```
should pass
style = lower

Fix from previous contribution, completely forgot about interfaces :(