### PR TITLE
New Rule: Call Transaction, Authority Check; Allow Abstract Final in Test Classes

### DIFF
--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -190,6 +190,23 @@
       },
       "type": "object"
     },
+    "CallTransactionAuthorityCheckConf": {
+      "additionalProperties": false,
+      "properties": {
+        "exclude": {
+          "description": "List of file regex filename patterns to exclude, case insensitive",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity",
+          "description": "Problem severity"
+        }
+      },
+      "type": "object"
+    },
     "ChainMainlyDeclarationsConf": {
       "additionalProperties": false,
       "properties": {
@@ -1150,6 +1167,17 @@
                 }
               ],
               "description": "Finds TYPE BEGIN with just one INCLUDE TYPE, and DATA with single INCLUDE STRUCTURE\nhttps://rules.abaplint.org/begin_single_include"
+            },
+            "call_transaction_authority_check": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CallTransactionAuthorityCheckConf"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Checks that usages of CALL TRANSACTION contain an authority-check.\nTags: Styleguide\nhttps://rules.abaplint.org/call_transaction_authority_check"
             },
             "chain_mainly_declarations": {
               "anyOf": [
@@ -3054,7 +3082,7 @@
         },
         "logic": {
           "$ref": "#/definitions/NewlineLogic",
-          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\n\nLess: the required number of newlines has to be less than \"newlineAmount\""
+          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\r \r Less: the required number of newlines has to be less than \"newlineAmount\""
         },
         "severity": {
           "$ref": "#/definitions/Severity",
@@ -3646,7 +3674,7 @@
           "type": "array"
         },
         "lines": {
-          "description": "An equal or higher number of sequential blank lines will trigger a violation. Example: if lines = 3, a maximum of 2 is allowed.",
+          "description": "An equal or higher number of sequential blank lines will trigger a violation.\r Example: if lines = 3, a maximum of 2 is allowed.",
           "type": "number"
         },
         "severity": {
@@ -3702,7 +3730,7 @@
           "type": "array"
         },
         "length": {
-          "description": "The smallest number of WHEN branches which will trigger a violation. Example: if length = 1, at least 2 branches are required",
+          "description": "The smallest number of WHEN branches which will trigger a violation.\r Example: if length = 1, at least 2 branches are required",
           "type": "number"
         },
         "severity": {

--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -3276,7 +3276,7 @@
           "type": "array"
         },
         "fieldSymbolStructure": {
-          "description": "Checks for FIELD-SYMBOL ... STRUCTURE",
+          "description": "Checks for FIELD-SYMBOLS ... STRUCTURE",
           "type": "boolean"
         },
         "load": {

--- a/packages/core/scripts/schema.ts
+++ b/packages/core/scripts/schema.ts
@@ -7,6 +7,7 @@ import {AmbiguousStatementConf} from "../src/rules/ambiguous_statement";
 import {AvoidUseConf} from "../src/rules/avoid_use";
 import {BeginEndNamesConf} from "../src/rules/begin_end_names";
 import {BeginSingleIncludeConf} from "../src/rules/begin_single_include";
+import {CallTransactionAuthorityCheckConf} from "../src/rules/call_transaction_authority_check";
 import {ChainMainlyDeclarationsConf} from "../src/rules/chain_mainly_declarations";
 import {CheckAbstractConf} from "../src/rules/check_abstract";
 import {CheckCommentsConf} from "../src/rules/check_comments";
@@ -121,6 +122,7 @@ export interface IConfig {
     "avoid_use"?: AvoidUseConf | boolean,
     "begin_end_names"?: BeginEndNamesConf | boolean,
     "begin_single_include"?: BeginSingleIncludeConf | boolean,
+    "call_transaction_authority_check"?: CallTransactionAuthorityCheckConf | boolean,
     "chain_mainly_declarations"?: ChainMainlyDeclarationsConf | boolean,
     "check_abstract"?: CheckAbstractConf | boolean,
     "check_comments"?: CheckCommentsConf | boolean,

--- a/packages/core/src/rules/call_transaction_authority_check.ts
+++ b/packages/core/src/rules/call_transaction_authority_check.ts
@@ -1,0 +1,49 @@
+import {BasicRuleConfig} from "./_basic_rule_config";
+import {ABAPRule} from "./_abap_rule";
+import {ABAPFile} from "../files";
+import {Issue, Statements} from "..";
+import {IRuleMetadata, RuleTag} from "./_irule";
+
+export class CallTransactionAuthorityCheckConf extends BasicRuleConfig {
+}
+export class CallTransactionAuthorityCheck extends ABAPRule {
+
+  private conf = new CallTransactionAuthorityCheckConf();
+
+  public getMetadata(): IRuleMetadata {
+    return {
+      key: "call_transaction_authority_check",
+      title: "Call Transaction Authority-Check",
+      shortDescription: `Checks that usages of CALL TRANSACTION contain an authority-check.`,
+      extendedInformation: `https://docs.abapopenchecks.org/checks/54/`,
+      tags: [RuleTag.Styleguide],
+      badExample: `CALL TRANSACTION 'FOO'.`,
+      goodExample: `CALL TRANSACTION 'FOO' WITH AUTHORITY-CHECK.`,
+    };
+  }
+
+  private getMessage(): string {
+    return "Add an authority check to CALL TRANSACTION";
+  }
+
+  public getConfig() {
+    return this.conf;
+  }
+
+  public setConfig(conf: CallTransactionAuthorityCheckConf) {
+    this.conf = conf;
+  }
+
+  public runParsed(file: ABAPFile) {
+    const issues: Issue[] = [];
+
+    for (const statNode of file.getStatements()) {
+      const statement = statNode.get();
+      if (statement instanceof Statements.CallTransaction && !statNode.concatTokensWithoutStringsAndComments().toUpperCase().includes("WITH AUTHORITY-CHECK")) {
+        issues.push(Issue.atStatement(file, statNode, this.getMessage(), this.getMetadata().key));
+      }
+    }
+    return issues;
+  }
+
+}

--- a/packages/core/src/rules/check_abstract.ts
+++ b/packages/core/src/rules/check_abstract.ts
@@ -47,7 +47,7 @@ export class CheckAbstract extends ABAPRule {
 
     for (const classDef of file.getInfo().listClassDefinitions()) {
       if (classDef.isAbstract === true) {
-        if (classDef.isFinal === true) {
+        if (classDef.isFinal === true && classDef.isForTesting === false) {
           issues.push(Issue.atIdentifier(
             classDef.identifier,
             this.getDescription(IssueType.AbstractAndFinal, classDef.name),

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -6,6 +6,7 @@ export * from "./ambiguous_statement";
 export * from "./avoid_use";
 export * from "./begin_end_names";
 export * from "./begin_single_include";
+export * from "./call_transaction_authority_check";
 export * from "./chain_mainly_declarations";
 export * from "./check_abstract";
 export * from "./check_comments";

--- a/packages/core/src/rules/obsolete_statement.ts
+++ b/packages/core/src/rules/obsolete_statement.ts
@@ -31,7 +31,7 @@ export class ObsoleteStatementConf extends BasicRuleConfig {
   public setExtended: boolean = true;
   /** Checks for WITH HEADER LINE */
   public withHeaderLine: boolean = true;
-  /** Checks for FIELD-SYMBOL ... STRUCTURE */
+  /** Checks for FIELD-SYMBOLS ... STRUCTURE */
   public fieldSymbolStructure: boolean = true;
   /** Checks for TYPE-POOLS */
   public typePools: boolean = true;
@@ -57,7 +57,7 @@ IS REQUESTED: https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abenlog
 
 WITH HEADER LINE: https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abapdata_header_line.htm
 
-FIELD-SYMBOL STRUCTURE: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapfield-symbols_obsolete_typing.htm
+FIELD-SYMBOLS STRUCTURE: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapfield-symbols_obsolete_typing.htm
 
 TYPE-POOLS: from 702, https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abennews-71-program_load.htm
 
@@ -149,7 +149,7 @@ LOAD addition: from 702, https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en
       if (this.conf.fieldSymbolStructure && sta instanceof Statements.FieldSymbol){
         const token = staNode.findDirectTokenByText("STRUCTURE");
         if (token) {
-          const issue = Issue.atToken(file, token, "FIELD-SYMBOL ... STRUCTURE is obsolete", this.getMetadata().key, this.conf.severity);
+          const issue = Issue.atToken(file, token, "FIELD-SYMBOLS ... STRUCTURE is obsolete", this.getMetadata().key, this.conf.severity);
           issues.push(issue);
         }
       }

--- a/packages/core/test/rules/call_transaction_authority_check.ts
+++ b/packages/core/test/rules/call_transaction_authority_check.ts
@@ -1,0 +1,10 @@
+import {CallTransactionAuthorityCheck} from "../../src/rules/call_transaction_authority_check";
+import {testRule} from "./_utils";
+
+const tests = [
+  {abap: "CALL TRANSACTION 'ZFOO' WITH AUTHORITY-CHECK.", cnt: 0},
+  {abap: "CALL TRANSACTION 'ZFOO' WITHOUT AUTHORITY-CHECK.", cnt: 1},
+  {abap: "CALL TRANSACTION 'ZFOO' AND SKIP FIRST SCREEN.", cnt: 1},
+];
+
+testRule(tests, CallTransactionAuthorityCheck);

--- a/packages/core/test/rules/check_abstract.ts
+++ b/packages/core/test/rules/check_abstract.ts
@@ -43,6 +43,11 @@ const tests = [
               METHODS:
                 normal_method.
           ENDCLASS.`, cnt: 0},
+  {abap: `CLASS lcl_abc DEFINITION ABSTRACT FINAL FOR TESTING.
+          PUBLIC SECTION.
+            METHODS:
+              normal_method.
+        ENDCLASS.`, cnt: 0},
 ];
 
 testRule(tests, CheckAbstract);


### PR DESCRIPTION
- Add new rule: call transaction, authority check (closes #1310 )
- Allow abstract and final for test classes (closes #1392 )
- Fix typo in `obsolete_statements`: `FIELD-SYMBOLS` instead of `FIELD-SYMBOL`