### PR TITLE
Fix test discovery for root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,3 @@ Versioning: semantic versioning is currently not followed, recommend fixing usag
 ### Debugging
 
 The [Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) extension will give you an overview of tests as well as codelens above each test to run/debug.
-
-Note that the root folder contains multiple packages and for this to work seamlessly you should open one of the subpackage folders and work from there.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Versioning: semantic versioning is currently not followed, recommend fixing usag
 [Syntax diagrams](https://syntax.abaplint.org)
 
 [Design documentation](https://github.com/abaplint/abaplint/blob/master/docs/design/index.adoc)
+
+### Debugging
+
+The [Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) extension will give you an overview of tests as well as codelens above each test to run/debug.
+
+Note that the root folder contains multiple packages and for this to work seamlessly you should open one of the subpackage folders and work from there.

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,12 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -313,6 +319,20 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
     },
     "chalk": {
       "version": "4.1.0",
@@ -366,6 +386,12 @@
         }
       }
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -411,6 +437,15 @@
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -890,6 +925,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
@@ -1374,7 +1415,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1398,6 +1439,12 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
@@ -1439,7 +1486,7 @@
       "dev": true
     },
     "railroad-diagrams": {
-      "version": "git+https://github.com/tabatkins/railroad-diagrams.git#8568bf5664239687b1fcebd2d4f2127a436bc87c",
+      "version": "git+https://github.com/tabatkins/railroad-diagrams.git#5ef54eeb853453779491c87d386d688c72505308",
       "from": "git+https://github.com/tabatkins/railroad-diagrams.git#gh-pages",
       "dev": true
     },
@@ -1504,6 +1551,12 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "semver": {
@@ -1723,6 +1776,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -1760,6 +1819,12 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1788,6 +1853,15 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
+      "requires": {
+        "sax": "^1.2.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": {
         "recursive": true,
         "reporter": "progress",
-        "spec": "build/test/**/*.js",
+        "spec": "packages/*/build/test/**/*.js",
         "require": "source-map-support/register"
     },
     "author": "Lars Hvam Petersen",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
         "link:monaco-into-playground": "cd web/playground && npm link @abaplint/monaco",
         "unlink-local": "cd web/playground && npm unlink --no-save @abaplint/monaco && npm unlink --no-save @abaplint/core && npm install && cd ../../packages/cli && npm unlink --no-save @abaplint/core && npm install && cd ../monaco && npm unlink --no-save @abaplint/core && npm install"
     },
+    "mocha": {
+        "recursive": true,
+        "reporter": "progress",
+        "spec": "build/test/**/*.js",
+        "require": "source-map-support/register"
+    },
     "author": "Lars Hvam Petersen",
     "license": "MIT",
     "homepage": "https://abaplint.org",
@@ -27,6 +33,9 @@
         "eslint": "^7.10.0",
         "eslint-plugin-import": "^2.22.1",
         "railroad-diagrams": "git+https://github.com/tabatkins/railroad-diagrams#gh-pages",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.3",
+        "chai": "^4.2.0",
+        "xml-js": "^1.6.11",
+        "vscode-languageserver-types": "^3.15.1"
     }
 }


### PR DESCRIPTION
This makes tests discoverable/runnable from the repository root by the test explorer extension.

Note that this is rather limited as you need to rebuild the whole thing on change, also navigation to each test only works if you are in the subfolder.