### PR TITLE
MethodChain 702, Add missing case

### DIFF
--- a/packages/core/src/rules/parser_702_chaining.ts
+++ b/packages/core/src/rules/parser_702_chaining.ts
@@ -61,7 +61,7 @@ Only active on target version 702 and below.`,
         }
         if (param.findDirectTokenByText("IMPORTING")
             || param.findDirectTokenByText("CHANGING")
-            || param.findDirectTokenByText("EXPORTING")) {
+            || param.findDirectTokenByText("EXCEPTIONS")) {
           const message = "This kind of method chaining not possible in 702";
           const issue = Issue.atPosition(file, param.getFirstToken().getStart(), message, this.getMetadata().key, this.conf.severity);
           issues.push(issue);

--- a/packages/core/src/rules/parser_702_chaining.ts
+++ b/packages/core/src/rules/parser_702_chaining.ts
@@ -60,7 +60,8 @@ Only active on target version 702 and below.`,
           continue;
         }
         if (param.findDirectTokenByText("IMPORTING")
-            || param.findDirectTokenByText("CHANGING")) {
+            || param.findDirectTokenByText("CHANGING")
+            || param.findDirectTokenByText("EXPORTING")) {
           const message = "This kind of method chaining not possible in 702";
           const issue = Issue.atPosition(file, param.getFirstToken().getStart(), message, this.getMetadata().key, this.conf.severity);
           issues.push(issue);

--- a/packages/core/test/rules/parser_702_chaining.ts
+++ b/packages/core/test/rules/parser_702_chaining.ts
@@ -43,6 +43,18 @@ describe("Rule: Parser702Chaining", () => {
     expect(issues.length).to.equal(1);
   });
 
+  it("issue3, exporting with exceptions", async () => {
+    const abap = `get_persistence( )->lock(
+    EXPORTING
+      p_objname_tr = objname
+    EXCEPTIONS
+      foreign_lock = 1
+      OTHERS       = 3 ).
+`;
+    const issues = await findIssues(abap);
+    expect(issues.length).to.equal(1);
+  });
+
   it("no issues, method call2", async () => {
     const abap = `get_repo_from_package(
       EXPORTING


### PR DESCRIPTION
ref #1399

The following case (from the referenced issue) is currently not reported:
![image](https://user-images.githubusercontent.com/27279305/97884198-139dbf00-1d26-11eb-907c-a67dd608587a.png)

add additional test case, check for `EXCEPTIONS` keyword