### PR TITLE
Fix default for local dependencies

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -37,7 +37,7 @@ export class Config implements IConfiguration {
       dependencies: [{
         url: "https://github.com/abaplint/deps",
         folder: "/deps",
-        files: "/src/**/*.*",
+        files: "/**/*.*",
       }],
       syntax: {
         version,


### PR DESCRIPTION
`folder` and `files` are concatenated so it should be `/deps/**/*.*` as a default