### PR TITLE
Make language version optional in config, up default to 755

### DIFF
--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -1034,7 +1034,7 @@
           "type": "array"
         },
         "recommendations": {
-          "description": "Tuple of Function Module Name to be replaced, the recommended alternative and\r the version from which the recommendation is valid.",
+          "description": "Tuple of Function Module Name to be replaced, the recommended alternative and the version from which the recommendation is valid.",
           "items": {
             "$ref": "#/definitions/Recommendations"
           },
@@ -3324,7 +3324,7 @@
         },
         "logic": {
           "$ref": "#/definitions/NewlineLogic",
-          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\r \r Less: the required number of newlines has to be less than \"newlineAmount\""
+          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\n\nLess: the required number of newlines has to be less than \"newlineAmount\""
         },
         "severity": {
           "$ref": "#/definitions/Severity",
@@ -3986,7 +3986,7 @@
           "type": "array"
         },
         "lines": {
-          "description": "An equal or higher number of sequential blank lines will trigger a violation.\r Example: if lines = 3, a maximum of 2 is allowed.",
+          "description": "An equal or higher number of sequential blank lines will trigger a violation. Example: if lines = 3, a maximum of 2 is allowed.",
           "type": "number"
         },
         "severity": {
@@ -4042,7 +4042,7 @@
           "type": "array"
         },
         "length": {
-          "description": "The smallest number of WHEN branches which will trigger a violation.\r Example: if length = 1, at least 2 branches are required",
+          "description": "The smallest number of WHEN branches which will trigger a violation. Example: if length = 1, at least 2 branches are required",
           "type": "number"
         },
         "severity": {

--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -1034,7 +1034,7 @@
           "type": "array"
         },
         "recommendations": {
-          "description": "Tuple of Function Module Name to be replaced, the recommended alternative and the version from which the recommendation is valid.",
+          "description": "Tuple of Function Module Name to be replaced, the recommended alternative and\r the version from which the recommendation is valid.",
           "items": {
             "$ref": "#/definitions/Recommendations"
           },
@@ -2558,7 +2558,6 @@
         }
       },
       "required": [
-        "version",
         "errorNamespace"
       ],
       "type": "object"
@@ -3325,7 +3324,7 @@
         },
         "logic": {
           "$ref": "#/definitions/NewlineLogic",
-          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\n\nLess: the required number of newlines has to be less than \"newlineAmount\""
+          "description": "Exact: the exact number of required newlines between methods is defined by \"newlineAmount\"\r \r Less: the required number of newlines has to be less than \"newlineAmount\""
         },
         "severity": {
           "$ref": "#/definitions/Severity",
@@ -3987,7 +3986,7 @@
           "type": "array"
         },
         "lines": {
-          "description": "An equal or higher number of sequential blank lines will trigger a violation. Example: if lines = 3, a maximum of 2 is allowed.",
+          "description": "An equal or higher number of sequential blank lines will trigger a violation.\r Example: if lines = 3, a maximum of 2 is allowed.",
           "type": "number"
         },
         "severity": {
@@ -4043,7 +4042,7 @@
           "type": "array"
         },
         "length": {
-          "description": "The smallest number of WHEN branches which will trigger a violation. Example: if length = 1, at least 2 branches are required",
+          "description": "The smallest number of WHEN branches which will trigger a violation.\r Example: if length = 1, at least 2 branches are required",
           "type": "number"
         },
         "severity": {

--- a/packages/core/src/_config.ts
+++ b/packages/core/src/_config.ts
@@ -26,7 +26,7 @@ export interface IDependency {
 
 export interface ISyntaxSettings {
   /** ABAP language version */
-  version: Version;
+  version?: Version;
   /** Report error for objects in this regex namespace. Types not in namespace will be void */
   errorNamespace: string;
   /** List of full named global constants */

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -13,7 +13,7 @@ export enum Version {
   Cloud = "Cloud",
 }
 
-export const defaultVersion = Version.v754;
+export const defaultVersion = Version.v755;
 
 export function getPreviousVersion(v: Version): Version {
   const all = Object.values(Version);


### PR DESCRIPTION
Resolves #1562 .

There are some whitespace inconsistencies when I run the schema script. I will undo them, but I'd like to know the cause - I did a fresh clone just to be sure and they still appear.