### PR TITLE
exit_or_check - fix confusion with rule config

### DIFF
--- a/packages/core/src/rules/exit_or_check.ts
+++ b/packages/core/src/rules/exit_or_check.ts
@@ -7,8 +7,8 @@ import {IRuleMetadata, RuleTag} from "./_irule";
 import {ABAPFile} from "../abap/abap_file";
 
 export class ExitOrCheckConf extends BasicRuleConfig {
-  public allowExit: boolean = true;
-  public allowCheck: boolean = true;
+  public allowExit: boolean = false;
+  public allowCheck: boolean = false;
 }
 
 export class ExitOrCheck extends ABAPRule {
@@ -54,11 +54,11 @@ https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#check-vs-re
           || statement.get() instanceof Statements.EndSelect
           || statement.get() instanceof Statements.EndDo) {
         stack.pop();
-      } else if (this.conf.allowCheck === true && statement.get() instanceof Statements.Check && stack.length === 0) {
+      } else if (this.conf.allowCheck === false && statement.get() instanceof Statements.Check && stack.length === 0) {
         const message = "CHECK is not allowed outside of loops";
         const issue = Issue.atStatement(file, statement, message, this.getMetadata().key, this.conf.severity);
         issues.push(issue);
-      } else if (this.conf.allowExit === true && statement.get() instanceof Statements.Exit && stack.length === 0) {
+      } else if (this.conf.allowExit === false && statement.get() instanceof Statements.Exit && stack.length === 0) {
         const message = "EXIT is not allowed outside of loops";
         const issue = Issue.atStatement(file, statement, message, this.getMetadata().key, this.conf.severity);
         issues.push(issue);

--- a/packages/core/test/rules/exit_or_check.ts
+++ b/packages/core/test/rules/exit_or_check.ts
@@ -26,6 +26,6 @@ const tests2 = [
 ];
 
 const config2 = new ExitOrCheckConf();
-config2.allowCheck = false;
-config2.allowExit = false;
+config2.allowCheck = true;
+config2.allowExit = true;
 testRule(tests2, ExitOrCheck, config2);


### PR DESCRIPTION
Default value for allow* should be false => exit or check is not allowed outside loop => error.
Value when checking should be false => it is not allowed, we will display error.