### PR TITLE
exit_or_check quickfix

### DIFF
--- a/packages/core/test/rules/exit_or_check.ts
+++ b/packages/core/test/rules/exit_or_check.ts
@@ -1,12 +1,12 @@
 import {ExitOrCheck, ExitOrCheckConf} from "../../src/rules/exit_or_check";
-import {testRule} from "./_utils";
+import {testRule, testRuleFix} from "./_utils";
 
 const tests = [
   {abap: `LOOP AT lt_usr02 INTO ls_usr02.
             EXIT.
           ENDLOOP.`, cnt: 0},
-  {abap: "EXIT.", cnt: 1},
-  {abap: "CHECK foo = bar.", cnt: 1},
+  {abap: "EXIT.", cnt: 1, fix: true},
+  {abap: "CHECK foo = bar.", cnt: 1, fix: true},
   {abap: `SELECT kunnr INTO lv_kunnr FROM kna1.
             CHECK sy-dbcnt > is_paging-skip.
           ENDSELECT.`, cnt: 0},
@@ -29,3 +29,10 @@ const config2 = new ExitOrCheckConf();
 config2.allowCheck = true;
 config2.allowExit = true;
 testRule(tests2, ExitOrCheck, config2);
+
+const fixes = [
+  {input: "EXIT.", output: "RETURN."},
+  {input: "CHECK foo = bar.", output: `IF NOT foo = bar.\n  RETURN.\nENDIF.`},
+];
+
+testRuleFix(fixes, ExitOrCheck);


### PR DESCRIPTION
The fix for CHECK adds NOT because it is easier than figuring out the correct operator + another check is handling that.