### PR TITLE
obsolete_statements - posix regex

### DIFF
--- a/packages/core/src/rules/obsolete_statement.ts
+++ b/packages/core/src/rules/obsolete_statement.ts
@@ -292,7 +292,7 @@ POSIX REGEX: https://help.sap.com/doc/abapdocu_755_index_htm/7.55/en-US/index.ht
         }
       }
 
-      if (configVersion >= Version.v755 && this.conf.regex) {
+      if (configVersion >= Version.v756 && this.conf.regex) {
         if (sta instanceof Statements.Find || sta instanceof Statements.Replace) {
           const concat = staNode.concatTokens().toUpperCase();
 

--- a/packages/core/src/rules/obsolete_statement.ts
+++ b/packages/core/src/rules/obsolete_statement.ts
@@ -292,7 +292,7 @@ POSIX REGEX: https://help.sap.com/doc/abapdocu_755_index_htm/7.55/en-US/index.ht
         }
       }
 
-      if (this.reg.getConfig().getVersion() >= Version.v755 && this.conf.regex &&
+      if (configVersion >= Version.v755 && this.conf.regex &&
         (sta instanceof Statements.Find || sta instanceof Statements.Replace)) {
         const concat = staNode.concatTokens().toUpperCase();
 

--- a/packages/core/src/rules/obsolete_statement.ts
+++ b/packages/core/src/rules/obsolete_statement.ts
@@ -60,6 +60,8 @@ export class ObsoleteStatementConf extends BasicRuleConfig {
   public sortByFS: boolean = true;
   /** Checks for CALL TRANSFORMATION OBJECTS */
   public callTransformation: boolean = true;
+  /** Check for POSIX REGEX usage */
+  public regex: boolean = true;
 }
 
 export class ObsoleteStatement extends ABAPRule {
@@ -106,7 +108,9 @@ FREE MEMORY: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abapfree
 
 SORT BY FS: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapsort_itab_obsolete.htm
 
-CALL TRANSFORMATION OBJECTS: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapcall_transformation_objects.htm`,
+CALL TRANSFORMATION OBJECTS: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapcall_transformation_objects.htm
+
+POSIX REGEX: https://help.sap.com/doc/abapdocu_755_index_htm/7.55/en-US/index.htm`,
     };
   }
 
@@ -284,6 +288,16 @@ CALL TRANSFORMATION OBJECTS: https://help.sap.com/doc/abapdocu_752_index_htm/7.5
 
         if (objects) {
           const issue = Issue.atStatement(file, staNode, "Use PARAMETERS instead of OBJECTS", this.getMetadata().key, this.conf.severity);
+          issues.push(issue);
+        }
+      }
+
+      if (this.reg.getConfig().getVersion() >= Version.v755 && this.conf.regex &&
+        (sta instanceof Statements.Find || sta instanceof Statements.Replace)) {
+        const concat = staNode.concatTokens().toUpperCase();
+
+        if (concat.includes("REGEX")) {
+          const issue = Issue.atStatement(file, staNode, "REGEX obsolete, use PCRE", this.getMetadata().key, this.conf.severity);
           issues.push(issue);
         }
       }

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -11,6 +11,7 @@ export enum Version {
   v753 = "v753",
   v754 = "v754",
   v755 = "v755",
+  v756 = "v756",
   Cloud = "Cloud", // Steampunk, SAP BTP ABAP Environment
 }
 

--- a/packages/core/test/rules/obsolete_statement.ts
+++ b/packages/core/test/rules/obsolete_statement.ts
@@ -85,7 +85,7 @@ async function findIssues(abap: string, version?: Version): Promise<readonly Iss
 }
 
 describe("test obsolete_statements rule - versions", () => {
-  it("no issues", async () => {
+  it("statements no issues", async () => {
     const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v754);
     expect(issue1.length).to.equal(0);
     const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v754);
@@ -97,7 +97,16 @@ describe("test obsolete_statements rule - versions", () => {
     expect(issue4.length).to.equal(0);
   });
 
-  it("issues", async () => {
+  it("methods no issues", async () => {
+    const issue1 = await findIssues("cl_abap_regex=>create_posix( foo ).", Version.v754);
+    expect(issue1.length).to.equal(0);
+    const issue2 = await findIssues("cl_abap_regex=>create_pcre( foo ).", Version.v754);
+    expect(issue2.length).to.equal(0);
+    const issue3 = await findIssues("cl_abap_matcher=>contains_posix( foo ).", Version.v754);
+    expect(issue3.length).to.equal(0);
+  });
+
+  it("statements issues", async () => {
     const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v755);
     expect(issue1.length).to.equal(1);
     const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v755);
@@ -107,6 +116,15 @@ describe("test obsolete_statements rule - versions", () => {
     expect(issue3.length).to.equal(1);
     const issue4 = await findIssues("REPLACE ALL OCCURRENCES OF PRCE 'foo' IN bar WITH 'test'.", Version.v755);
     expect(issue4.length).to.equal(0);
+  });
+
+  it("methods issues", async () => {
+    const issue1 = await findIssues("cl_abap_regex=>create_posix( foo ).", Version.v755);
+    expect(issue1.length).to.equal(1);
+    const issue2 = await findIssues("cl_abap_regex=>create_pcre( foo ).", Version.v755);
+    expect(issue2.length).to.equal(0);
+    const issue3 = await findIssues("cl_abap_matcher=>contains_posix( foo ).", Version.v755);
+    expect(issue3.length).to.equal(1);
   });
 });
 

--- a/packages/core/test/rules/obsolete_statement.ts
+++ b/packages/core/test/rules/obsolete_statement.ts
@@ -86,9 +86,9 @@ async function findIssues(abap: string, version?: Version): Promise<readonly Iss
 
 describe("test obsolete_statements rule - versions", () => {
   it("no issues", async () => {
-    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'", Version.v754);
+    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v754);
     expect(issue1.length).to.equal(0);
-    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'", Version.v754);
+    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v754);
     expect(issue2.length).to.equal(0);
 
     const issue3 = await findIssues("REPLACE ALL OCCURRENCES OF REGEX 'foo' IN bar WITH 'test'.", Version.v754);
@@ -98,9 +98,9 @@ describe("test obsolete_statements rule - versions", () => {
   });
 
   it("issues", async () => {
-    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'", Version.v755);
+    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v755);
     expect(issue1.length).to.equal(1);
-    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'", Version.v755);
+    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v755);
     expect(issue2.length).to.equal(0);
 
     const issue3 = await findIssues("REPLACE ALL OCCURRENCES OF REGEX 'foo' IN bar WITH 'test'.", Version.v755);

--- a/packages/core/test/rules/obsolete_statement.ts
+++ b/packages/core/test/rules/obsolete_statement.ts
@@ -86,44 +86,44 @@ async function findIssues(abap: string, version?: Version): Promise<readonly Iss
 
 describe("test obsolete_statements rule - versions", () => {
   it("statements no issues", async () => {
-    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v754);
-    expect(issue1.length).to.equal(0);
-    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v754);
-    expect(issue2.length).to.equal(0);
-
-    const issue3 = await findIssues("REPLACE ALL OCCURRENCES OF REGEX 'foo' IN bar WITH 'test'.", Version.v754);
-    expect(issue3.length).to.equal(0);
-    const issue4 = await findIssues("REPLACE ALL OCCURRENCES OF PRCE 'foo' IN bar WITH 'test'.", Version.v754);
-    expect(issue4.length).to.equal(0);
-  });
-
-  it("methods no issues", async () => {
-    const issue1 = await findIssues("cl_abap_regex=>create_posix( foo ).", Version.v754);
-    expect(issue1.length).to.equal(0);
-    const issue2 = await findIssues("cl_abap_regex=>create_pcre( foo ).", Version.v754);
-    expect(issue2.length).to.equal(0);
-    const issue3 = await findIssues("cl_abap_matcher=>contains_posix( foo ).", Version.v754);
-    expect(issue3.length).to.equal(0);
-  });
-
-  it("statements issues", async () => {
     const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v755);
-    expect(issue1.length).to.equal(1);
+    expect(issue1.length).to.equal(0);
     const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v755);
     expect(issue2.length).to.equal(0);
 
     const issue3 = await findIssues("REPLACE ALL OCCURRENCES OF REGEX 'foo' IN bar WITH 'test'.", Version.v755);
-    expect(issue3.length).to.equal(1);
+    expect(issue3.length).to.equal(0);
     const issue4 = await findIssues("REPLACE ALL OCCURRENCES OF PRCE 'foo' IN bar WITH 'test'.", Version.v755);
     expect(issue4.length).to.equal(0);
   });
 
-  it("methods issues", async () => {
+  it("methods no issues", async () => {
     const issue1 = await findIssues("cl_abap_regex=>create_posix( foo ).", Version.v755);
-    expect(issue1.length).to.equal(1);
+    expect(issue1.length).to.equal(0);
     const issue2 = await findIssues("cl_abap_regex=>create_pcre( foo ).", Version.v755);
     expect(issue2.length).to.equal(0);
     const issue3 = await findIssues("cl_abap_matcher=>contains_posix( foo ).", Version.v755);
+    expect(issue3.length).to.equal(0);
+  });
+
+  it("statements issues", async () => {
+    const issue1 = await findIssues("FIND REGEX 'foo' IN 'bar'.", Version.v756);
+    expect(issue1.length).to.equal(1);
+    const issue2 = await findIssues("FIND PRCE 'foo' IN 'bar'.", Version.v756);
+    expect(issue2.length).to.equal(0);
+
+    const issue3 = await findIssues("REPLACE ALL OCCURRENCES OF REGEX 'foo' IN bar WITH 'test'.", Version.v756);
+    expect(issue3.length).to.equal(1);
+    const issue4 = await findIssues("REPLACE ALL OCCURRENCES OF PRCE 'foo' IN bar WITH 'test'.", Version.v756);
+    expect(issue4.length).to.equal(0);
+  });
+
+  it("methods issues", async () => {
+    const issue1 = await findIssues("cl_abap_regex=>create_posix( foo ).", Version.v756);
+    expect(issue1.length).to.equal(1);
+    const issue2 = await findIssues("cl_abap_regex=>create_pcre( foo ).", Version.v756);
+    expect(issue2.length).to.equal(0);
+    const issue3 = await findIssues("cl_abap_matcher=>contains_posix( foo ).", Version.v756);
     expect(issue3.length).to.equal(1);
   });
 });

--- a/packages/core/test/version.ts
+++ b/packages/core/test/version.ts
@@ -9,7 +9,7 @@ describe("getPreviousVersion", () => {
   });
 
   it("cloud", () => {
-    expect(getPreviousVersion(Version.Cloud)).to.equal(Version.v755);
+    expect(getPreviousVersion(Version.Cloud)).to.equal(Version.v756);
   });
 
   it("open-abap", () => {


### PR DESCRIPTION
Ref #2132.

Posix regex becomes obsolete in abap version 7.56, however this versions is not yet available to the public.
Should I add new abap version 7.56 for this?

Regex in string function is not in this as I don't know how to easily check built-in methods (and I don't have the full list of methods that use this). Generic parameter name "regex" would create false positives for user defined methods.