### PR TITLE
Fix cases where keywords are not uppercased before comparison

### DIFF
--- a/packages/core/src/abap/5_syntax/statements/shift.ts
+++ b/packages/core/src/abap/5_syntax/statements/shift.ts
@@ -19,7 +19,7 @@ export class Shift implements StatementSyntax {
     }
 
     const targetType = new Target().runSyntax(target, scope, filename);
-    if (node.concatTokens().includes(" IN BYTE MODE")) {
+    if (node.concatTokens().toUpperCase().includes(" IN BYTE MODE")) {
       if (TypeUtils.isHexLike(targetType) === false) {
         throw new Error("Shift, Target not hex like");
       }

--- a/packages/core/src/rules/check_subrc.ts
+++ b/packages/core/src/rules/check_subrc.ts
@@ -129,7 +129,7 @@ FIND statement with MATCH COUNT is considered okay if subrc is not checked`,
 
   private isExemptedFind(s: StatementNode): boolean {
 // see https://github.com/abaplint/abaplint/issues/2130
-    return s.concatTokens().includes(" MATCH COUNT ") === true;
+    return s.concatTokens().toUpperCase().includes(" MATCH COUNT ") === true;
   }
 
   private checksDbcnt(index: number, statements: readonly StatementNode[]): boolean {

--- a/packages/core/src/rules/many_parentheses.ts
+++ b/packages/core/src/rules/many_parentheses.ts
@@ -84,7 +84,7 @@ ENDIF.
       if (c instanceof TokenNode) {
         current = c.get().getStr().toUpperCase();
       } else if (c instanceof ExpressionNode && c.get() instanceof Expressions.CondSub) {
-        if (c.getFirstToken().getStr() === "NOT") {
+        if (c.getFirstToken().getStr().toUpperCase() === "NOT") {
           return [];
         }
         const i = c.findDirectExpression(Expressions.Cond);

--- a/packages/core/src/rules/select_performance.ts
+++ b/packages/core/src/rules/select_performance.ts
@@ -73,7 +73,7 @@ SELECT *: not reported if using INTO/APPENDING CORRESPONDING FIELDS OF`,
       if (this.conf.endSelect) {
         for (const s of stru.findAllStructures(Structures.Select) || []) {
           const select = s.findDirectStatement(Statements.SelectLoop);
-          if (select === undefined || select.concatTokens().includes("PACKAGE SIZE")) {
+          if (select === undefined || select.concatTokens().toUpperCase().includes("PACKAGE SIZE")) {
             continue;
           }
           const message = "Avoid use of ENDSELECT";


### PR DESCRIPTION
I looked for all calls to `getStr` and `concatTokens` where keyword case would be an issue.