### PR TITLE
no_chained_assignments example

### DIFF
--- a/packages/core/src/rules/no_chained_assignment.ts
+++ b/packages/core/src/rules/no_chained_assignment.ts
@@ -23,7 +23,7 @@ export class NoChainedAssignment extends ABAPRule {
       tags: [RuleTag.SingleFile, RuleTag.Styleguide],
       badExample: `var1 = var2 = var3.`,
       goodExample: `var2 = var3.
-var1 = var3.`,
+var1 = var2.`,
     };
   }
 


### PR DESCRIPTION
See this:

```abap
REPORT ZTEST.
DATA v1 TYPE c LENGTH 5.
DATA v2 TYPE c LENGTH 2.
DATA v3 TYPE c LENGTH 5 VALUE 'ABCDE'.

v1 = v2 = v3.
WRITE v1. " AB

v2 = v3.
v1 = v3.
WRITE v1.  " ABCDE
```