### PR TITLE
Bump up ABAP version to 7.56

### DIFF
--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -15,7 +15,7 @@ export enum Version {
   Cloud = "Cloud", // Steampunk, SAP BTP ABAP Environment
 }
 
-export const defaultVersion = Version.v755;
+export const defaultVersion = Version.v756;
 
 export function getPreviousVersion(v: Version): Version {
   if (v === Version.OpenABAP) {


### PR DESCRIPTION
ABAP 7.56 is already available to all customers:
https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abennews-756.htm