### PR TITLE
Rule no_public_attributes can ignore test classes

### DIFF
--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -3980,13 +3980,18 @@
           },
           "type": "array"
         },
+        "ignoreTestClasses": {
+          "description": "Option to ignore test classes for this check.",
+          "type": "boolean"
+        },
         "severity": {
           "$ref": "#/definitions/Severity",
           "description": "Problem severity"
         }
       },
       "required": [
-        "allowReadOnly"
+        "allowReadOnly",
+        "ignoreTestClasses"
       ],
       "type": "object"
     },

--- a/packages/core/src/rules/no_public_attributes.ts
+++ b/packages/core/src/rules/no_public_attributes.ts
@@ -11,6 +11,8 @@ import {ABAPFile} from "../abap/abap_file";
 export class NoPublicAttributesConf extends BasicRuleConfig {
   /** Allows public attributes, if they are declared as READ-ONLY. */
   public allowReadOnly: boolean = false;
+  /** Option to ignore test classes for this check. */
+  public ignoreTestClasses: boolean = false;
 }
 
 export class NoPublicAttributes extends ABAPRule {
@@ -81,6 +83,9 @@ Exceptions are excluded from this rule.`,
       if (this.conf.allowReadOnly === true && attr.readOnly) {
         continue;
       } else if (attr.level === AttributeLevel.Constant) {
+        continue;
+      } else if ((this.conf.ignoreTestClasses === true)
+        && this.file.getFilename().includes(".testclasses.")) {
         continue;
       }
       const issue = Issue.atIdentifier(attr.identifier, this.getDescription(attr.name), this.getMetadata().key, this.conf.severity);


### PR DESCRIPTION
The rule is OK, but should be exemptable for test classes. Public attributes simplify test code e.g. for spy pattern in test doubles. (Personally I think `true` should even be default).