### PR TITLE
Fix "TABLE OF" for table types

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/type_table.ts
+++ b/packages/core/src/abap/2_statements/expressions/type_table.ts
@@ -10,6 +10,8 @@ export class TypeTable extends Expression {
     const header = "WITH HEADER LINE";
     const initial = seq("INITIAL SIZE", Constant);
 
+    const generic = seq(opt(alt("STANDARD", "HASHED", "INDEX", "SORTED", "ANY")), "TABLE");
+
     const normal1 = seq(opt(alt("STANDARD", "HASHED", "INDEX", "SORTED", "ANY")),
                         "TABLE OF",
                         opt("REF TO"),
@@ -26,9 +28,10 @@ export class TypeTable extends Expression {
 
     // a maximum of 15 secondary table keys can be defined
     // "WITH" is not allowed as a field name in keys
-    const typetable = seq(normal1,
+    const typetable = alt(generic,
+                      seq(normal1,
                           alt(opt(per(header, initial, plusPrio(TypeTableKey))),
-                              seq(plus(TypeTableKey), optPrio(initial))));
+                              seq(plus(TypeTableKey), optPrio(initial)))));
 
     const occurs = seq("OCCURS", Integer);
 

--- a/packages/core/src/abap/2_statements/expressions/type_table.ts
+++ b/packages/core/src/abap/2_statements/expressions/type_table.ts
@@ -11,8 +11,7 @@ export class TypeTable extends Expression {
     const initial = seq("INITIAL SIZE", Constant);
 
     const normal1 = seq(opt(alt("STANDARD", "HASHED", "INDEX", "SORTED", "ANY")),
-                        "TABLE",
-                        opt("OF"),
+                        "TABLE OF",
                         opt("REF TO"),
                         opt(TypeName));
 

--- a/packages/core/src/abap/2_statements/expressions/type_table.ts
+++ b/packages/core/src/abap/2_statements/expressions/type_table.ts
@@ -28,8 +28,7 @@ export class TypeTable extends Expression {
 
     // a maximum of 15 secondary table keys can be defined
     // "WITH" is not allowed as a field name in keys
-    const typetable = alt(generic,
-                      seq(normal1,
+    const typetable = alt(generic,seq(normal1,
                           alt(opt(per(header, initial, plusPrio(TypeTableKey))),
                               seq(plus(TypeTableKey), optPrio(initial)))));
 

--- a/packages/core/test/abap/statements/type.ts
+++ b/packages/core/test/abap/statements/type.ts
@@ -43,6 +43,7 @@ statementVersion(versions, "TYPE", Statements.Type);
 
 
 const fails = [
+  `TYPES ty_itab TYPE STANDARD TABLE string.`,
   `TYPES moo TYPE SORTED TABLE OF foo_bar WITH NON-UNIQUE KEY and with.`,
 ];
 statementExpectFail(fails, "TYPES");


### PR DESCRIPTION
Fix so first statement is syntax error:

```abap
DATA itab1 TYPE STANDARD TABLE string. "<<< should error
DATA itab2 TYPE STANDARD TABLE OF string.
```

Ref https://github.com/abaplint/abaplint/issues/2907