### PR TITLE
Run fully_type_itabs on DATA and TYPES statements.

### DIFF
--- a/packages/core/src/rules/fully_type_itabs.ts
+++ b/packages/core/src/rules/fully_type_itabs.ts
@@ -38,7 +38,7 @@ DATA lt_bar TYPE STANDARD TABLE OF ty.`,
     const issues: Issue[] = [];
 
     for (const statement of file.getStatements()) {
-      if (!(statement.get() instanceof Statements.Data)) {
+      if (!(statement.get() instanceof Statements.Data || statement.get() instanceof Statements.Type)) {
         continue;
       }
 

--- a/packages/core/test/rules/fully_type_itabs.ts
+++ b/packages/core/test/rules/fully_type_itabs.ts
@@ -37,6 +37,13 @@ describe("Rule: fully_type_itabs", () => {
     expect(issues.length).to.equal(1);
   });
 
+  it("specify table type", async () => {
+    const abap = `TYPES lt_foo TYPE TABLE OF ty.`;
+    const file = new MemoryFile("zidentical_cond.prog.abap", abap);
+    const issues = await run(file);
+    expect(issues.length).to.equal(1);
+  });
+
   it("specify table key", async () => {
     const abap = `DATA lt_bar TYPE STANDARD TABLE OF ty.`;
     const file = new MemoryFile("zidentical_cond.prog.abap", abap);


### PR DESCRIPTION
Dev team reported false negatives for internal tables defined through a type variable.