### PR TITLE
Recommend VS code extensions for Test explorer UI

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,9 @@
 	"recommendations": [
     "mrmlnc.vscode-duplicate",
     "dbaeumer.vscode-eslint",
-    "pflannery.vscode-versionlens"
+	"pflannery.vscode-versionlens",
+	"hbenl.vscode-mocha-test-adapter",
+	"hbenl.vscode-test-explorer"
 	],
 	"unwantedRecommendations": [
 


### PR DESCRIPTION
Test Explorer UI is mentioned in the docs but not enforced by VS code recommandations.
Also, it requires an additional test adapter that's not documented.