### PR TITLE
Raise issue when abstract methods in non-abstract classes

### DIFF
--- a/packages/core/src/rules/implement_methods.ts
+++ b/packages/core/src/rules/implement_methods.ts
@@ -97,7 +97,15 @@ export class ImplementMethods extends ABAPRule {
           const issue = Issue.atIdentifier(found, "Do not implement abstract method \"" + md.name + "\"", this.getMetadata().key, this.conf.severity);
           ret.push(issue);
         }
-        continue;
+        if (def.isAbstract) {
+          continue;
+        }
+        else {
+          const message = "Abstract methods can only be defined in abstract classes.";
+          const issue = Issue.atIdentifier(def.identifier, message, this.getMetadata().key, this.conf.severity);
+          ret.push(issue);
+          break;
+        }
       }
 
       if (impl === undefined) {
@@ -215,7 +223,14 @@ export class ImplementMethods extends ABAPRule {
 
       for (const m of this.findInterfaceMethods(idef)) {
         if (this.isAbstract(m, interfaceInfo, def)) {
-          continue;
+          if (def.isAbstract) {
+            continue;
+          } else {
+            const message = "Abstract methods can only be defined in abstract classes.";
+            const issue = Issue.atIdentifier(def.identifier, message, this.getMetadata().key, this.conf.severity);
+            ret.push(issue);
+            break;
+          }
         }
 
         if (this.isImplemented(m, def, impl) === false) {

--- a/packages/core/test/rules/implement_methods.ts
+++ b/packages/core/test/rules/implement_methods.ts
@@ -78,9 +78,9 @@ describe("Rules, implement_methods", () => {
     expect(issues.length).to.equals(0);
   });
 
-  it("abstract method", async () => {
+  it("abstract method in abstract class", async () => {
     const contents =
-    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+    `CLASS zcl_foobar DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
       PUBLIC SECTION.
         METHODS foobar ABSTRACT.
      ENDCLASS.
@@ -90,8 +90,20 @@ describe("Rules, implement_methods", () => {
     expect(issues.length).to.equals(0);
   });
 
+  it("abstract method in non-abstract class", async () => {
+    const contents =
+    `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+      PUBLIC SECTION.
+        METHODS foobar ABSTRACT.
+     ENDCLASS.
+     CLASS zcl_foobar IMPLEMENTATION.
+     ENDCLASS.`;
+    const issues = await runMulti([{filename: "cl_foo.clas.abap", contents}]);
+    expect(issues.length).to.equals(1);
+  });
+
   it("abstract method, do not implement", async () => {
-    const contents = `CLASS zcl_foobar DEFINITION PUBLIC FINAL CREATE PUBLIC.
+    const contents = `CLASS zcl_foobar DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
         PUBLIC SECTION.
           METHODS foobar ABSTRACT.
       ENDCLASS.
@@ -253,7 +265,7 @@ describe("Rules, implement_methods", () => {
     expect(issues.length).to.equals(0);
   });
 
-  it("INTERFACES ABSTRACT METHODS", async () => {
+  it("INTERFACES ABSTRACT METHODS abstract class", async () => {
     const prog = `
 INTERFACE lcl_intf.
   METHODS method_name.
@@ -269,6 +281,24 @@ ENDCLASS.`;
     const issues = await runMulti([
       {filename: "zfoobar.prog.abap", contents: prog}]);
     expect(issues.length).to.equals(0);
+  });
+
+  it("INTERFACES ABSTRACT METHODS non-abstract class", async () => {
+    const prog = `
+INTERFACE lcl_intf.
+  METHODS method_name.
+ENDINTERFACE.
+
+CLASS lcl_bar DEFINITION.
+  PUBLIC SECTION.
+    INTERFACES lcl_intf ABSTRACT METHODS method_name.
+ENDCLASS.
+
+CLASS lcl_bar IMPLEMENTATION.
+ENDCLASS.`;
+    const issues = await runMulti([
+      {filename: "zfoobar.prog.abap", contents: prog}]);
+    expect(issues.length).to.equals(1);
   });
 
   it("class, local interface", async () => {


### PR DESCRIPTION
Unrelated to https://github.com/abaplint/abaplint/pull/3717 but found when testing
We used to allow abstract methods in non-abstract classes. This PR enforces that abstract methods can only be declared in abstract classes. 
Error message is the one returned by SAP syntax check.