### PR TITLE
Implement FREE and REFRESH statements

### DIFF
--- a/packages/core/src/abap/5_syntax/statements/free.ts
+++ b/packages/core/src/abap/5_syntax/statements/free.ts
@@ -1,0 +1,15 @@
+import * as Expressions from "../../2_statements/expressions";
+import {StatementNode} from "../../nodes";
+import {Target} from "../expressions/target";
+import {StatementSyntax} from "../_statement_syntax";
+import {SyntaxInput} from "../_syntax_input";
+
+export class Free implements StatementSyntax {
+  public runSyntax(node: StatementNode, input: SyntaxInput): void {
+
+    for (const t of node.findDirectExpressions(Expressions.Target)) {
+      Target.runSyntax(t, input);
+    }
+
+  }
+}

--- a/packages/core/src/abap/5_syntax/statements/refresh.ts
+++ b/packages/core/src/abap/5_syntax/statements/refresh.ts
@@ -1,0 +1,15 @@
+import * as Expressions from "../../2_statements/expressions";
+import {StatementNode} from "../../nodes";
+import {Target} from "../expressions/target";
+import {StatementSyntax} from "../_statement_syntax";
+import {SyntaxInput} from "../_syntax_input";
+
+export class Refresh implements StatementSyntax {
+  public runSyntax(node: StatementNode, input: SyntaxInput): void {
+
+    for (const t of node.findDirectExpressions(Expressions.Target)) {
+      Target.runSyntax(t, input);
+    }
+
+  }
+}

--- a/packages/core/src/abap/5_syntax/syntax.ts
+++ b/packages/core/src/abap/5_syntax/syntax.ts
@@ -68,6 +68,8 @@ import {Do} from "./statements/do";
 import {Concatenate} from "./statements/concatenate";
 import {CallFunction} from "./statements/call_function";
 import {Clear} from "./statements/clear";
+import {Refresh} from "./statements/refresh";
+import {Free} from "./statements/free";
 import {Replace} from "./statements/replace";
 import {GetBit} from "./statements/get_bit";
 import {Raise} from "./statements/raise";
@@ -197,6 +199,8 @@ if (Object.keys(map).length === 0) {
   addToMap(new DeleteInternal());
   addToMap(new DeleteCluster());
   addToMap(new Clear());
+  addToMap(new Free());
+  addToMap(new Refresh());
   addToMap(new Receive());
   addToMap(new GetBit());
   addToMap(new ClassLocalFriends());

--- a/packages/core/test/rules/unused_variables.ts
+++ b/packages/core/test/rules/unused_variables.ts
@@ -405,6 +405,30 @@ EXPORT values = lt_values TO DATABASE rsix(zz) FROM lv_test ID lv_id.`;
     expect(issues.length).to.equal(0);
   });
 
+  it("CLEAR", async () => {
+    const abap = `
+    DATA bar TYPE abap_bool.
+    CLEAR bar.`;
+    const issues = await runSingle(abap);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("FREE", async () => {
+    const abap = `
+    DATA bar TYPE abap_bool.
+    FREE bar.`;
+    const issues = await runSingle(abap);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("REFRESH", async () => {
+    const abap = `
+    DATA bar TYPE abap_bool.
+    REFRESH bar.`;
+    const issues = await runSingle(abap);
+    expect(issues.length).to.equal(0);
+  });
+
   it("Table expression", async () => {
     const abap = `
     DATA tab TYPE STANDARD TABLE OF i.


### PR DESCRIPTION
Backstory: quick fixes of unused_variables where the variables were only used in a FREE or REFRESH statement would delete the variable and result in syntax errors not detected by abaplint.