### PR TITLE
fix: Support CDS field annotations with colon syntax and unary operators

### DIFF
--- a/packages/core/src/cds/expressions/cds_annotation.ts
+++ b/packages/core/src/cds/expressions/cds_annotation.ts
@@ -7,7 +7,10 @@ export class CDSAnnotation extends Expression {
   public getRunnable(): IStatementRunnable {
     const nameWithSlash = seq(regex(/^\w+$/), star(seq("/", regex(/^\w+$/))));
 
-    return seq(regex(/^@\w+$/), star(seq(".", nameWithSlash)), opt(":"),
-               opt(alt(CDSAnnotationArray, CDSAnnotationObject, CDSAnnotationSimple)));
+    // Support both "@Name" (single token) and "@ Name" (two tokens with space)
+    const annotationStart = alt(regex(/^@\w+$/), seq("@", regex(/^\w+$/)));
+
+    return seq(annotationStart, star(seq(".", nameWithSlash)),
+               opt(seq(":", alt(CDSAnnotationArray, CDSAnnotationObject, CDSAnnotationSimple))));
   }
 }

--- a/packages/core/src/cds/expressions/cds_arithmetics.ts
+++ b/packages/core/src/cds/expressions/cds_arithmetics.ts
@@ -9,10 +9,14 @@ export class CDSArithmetics extends Expression {
     const val = altPrio(CDSInteger, CDSFunction, CDSCase, CDSCast, CDSString, CDSAggregate, name);
     const operator = altPrio("+", "-", "*", "/");
 
+    // Support unary operators (e.g., "- field" in CASE expressions)
+    const unary = altPrio("-", "+");
+    const unaryExpression = seq(unary, val);
+
     const operatorValue = seq(operator, val);
     const paren = seq("(", val, plusPrio(operatorValue), ")");
     const noParen = seq(val, plusPrio(operatorValue));
     // todo: this is pretty bad, it needs a rewrite
-    return altPrio(seq(paren, starPrio(operatorValue)), noParen);
+    return altPrio(unaryExpression, seq(paren, starPrio(operatorValue)), noParen);
   }
 }


### PR DESCRIPTION
This commit fixes two parsing issues in the CDS parser:

1. Field annotations with colon syntax (e.g., @Semantics.businessDate.from:true)
   - Modified cds_annotation.ts to pair colon with value as single optional unit
   - Added support for both @Name and @ Name token patterns

2. Unary operators in arithmetic expressions (e.g., then - field in CASE)
   - Modified cds_arithmetics.ts to support unary minus and plus operators
   - Added unaryExpression alternative for single-operand expressions

Added 8 comprehensive test cases to prevent regression. Fixes parsing of SAP standard CDS views like I_BusinessPartnerDefaultAddr and I_JntVntrRmngCutbackAmt.

fixes #3772 