### PR TITLE
fix(cds-lexer): treat @ as token separator to handle concatenated annotations

### DIFF
--- a/packages/core/src/cds/cds_lexer.ts
+++ b/packages/core/src/cds/cds_lexer.ts
@@ -155,6 +155,11 @@ export class CDSLexer {
           build = result.add(build, row, col, mode);
           result.add(next, row, col, mode);
           break;
+        case "@":
+          // @ starts a new annotation; flush current token and start building with @
+          build = result.add(build, row, col, mode);
+          build = "@";
+          break;
         default:
           build += next;
           break;

--- a/packages/core/test/cds/cds_parser.ts
+++ b/packages/core/test/cds/cds_parser.ts
@@ -1431,4 +1431,14 @@ define view Test as select from tab1 as T1
     expect(parsed).to.be.instanceof(ExpressionNode);
   });
 
+  it("two annotations concatenated on same line without space", () => {
+    const cds = `@AbapCatalog.preserveKey:true@AbapCatalog.compiler.compareFilter:true
+define view ZTestView as select from ztable {
+  key field1
+}`;
+    const file = new MemoryFile("ztestview.ddls.asddls", cds);
+    const parsed = new CDSParser().parse(file);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
 });


### PR DESCRIPTION
Two annotations written on the same line without a space (e.g. @AbapCatalog.preserveKey:true@AbapCatalog.compiler.compareFilter:true) were lexed as a single token, causing parse failures. Flushing the current build and starting a new token on @ fixes this.