### PR TITLE
Fix typo

### DIFF
--- a/packages/core/src/rules/fm_global_parameters_obsolete.ts
+++ b/packages/core/src/rules/fm_global_parameters_obsolete.ts
@@ -16,7 +16,7 @@ export class FMGlobalParametersObsolete implements IRule {
     return {
       key: "fm_global_parameters_obsolete",
       title: "FM Global Parameters Obsolete",
-      shortDescription: `Check for function modules with global parameteers`,
+      shortDescription: `Check for function modules with global parameters`,
       extendedInformation: `https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abenglobal_parameters_obsolete.htm`,
       tags: [],
     };


### PR DESCRIPTION
The shortDescription of `fm_global_parameters_obsolete` contained a `parameteers` typo

Alexander von Rhein (rhein@cqse.eu)