### PR TITLE
bugfix: allow CASE expression inside CAST in SELECT field list

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/sql_function.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_function.ts
@@ -4,6 +4,7 @@ import {Expression, ver, seq, tok, altPrio, optPrio, regex as reg} from "../comb
 import {IStatementRunnable} from "../statement_runnable";
 import {Integer} from "./integer";
 import {SQLFunctionInput} from "./sql_function_input";
+import {SQLCase} from "./sql_case";
 
 export class SQLFunction extends Expression {
   public getRunnable(): IStatementRunnable {
@@ -23,7 +24,8 @@ export class SQLFunction extends Expression {
     // note: the function names are not keywords, they are usually in lower case
     const abs = ver(Version.v740sp05, seq(reg(/^abs$/i), tok(ParenLeftW), SQLFunctionInput, tok(WParenRightW)));
     // yea, 750 is correct, but it also works technically in version v740sp05
-    const cast = ver(Version.v750, seq(reg(/^cast$/i), tok(ParenLeftW), SQLFunctionInput, "AS", castTypes, tok(WParenRightW)));
+    const castInput = altPrio(SQLCase, SQLFunctionInput);
+    const cast = ver(Version.v750, seq(reg(/^cast$/i), tok(ParenLeftW), castInput, "AS", castTypes, tok(WParenRightW)));
     const ceil = ver(Version.v740sp05, seq(reg(/^ceil$/i), tok(ParenLeftW), SQLFunctionInput, tok(WParenRightW)));
     const coalesce = ver(Version.v740sp05, seq(reg(/^coalesce$/i), tok(ParenLeftW), SQLFunctionInput, commaParam, optPrio(commaParam), tok(WParenRightW)));
     const concat = ver(Version.v750, seq(reg(/^concat$/i), tok(ParenLeftW), SQLFunctionInput, commaParam, tok(WParenRightW)));

--- a/packages/core/test/abap/statements/select.ts
+++ b/packages/core/test/abap/statements/select.ts
@@ -556,6 +556,9 @@ WHERE  but000~partner IN ('1000' , '2000' , '3000' ).`,
       AND a~werks IN @s_cedi
       AND a~mmsta IN @s_mmsta
       AND a~lgfsb = @space.`,
+
+  `SELECT CAST( CASE T1~_DATAAGING WHEN '00000000' THEN ' ' ELSE 'X' END AS CHAR ) AS XARCH FROM BSEG AS T1 INTO TABLE @DATA(lt_result).`,
+  `SELECT CAST( CASE T1~FKBER_LONG WHEN ' ' THEN T1~FKBER ELSE T1~FKBER_LONG END AS CHAR ) AS FKBER FROM BSEG AS T1 INTO TABLE @DATA(lt_result).`,
 ];
 
 statementType(tests, "SELECT", Statements.Select);


### PR DESCRIPTION
Previously, the SQL CAST expression only accepted SQLFunctionInput as its inner expression, which prevented valid ABAP SQL like:

  SELECT CAST( CASE field WHEN 'X' THEN ' ' ELSE 'X' END AS CHAR ) AS col
    FROM ztab INTO TABLE @DATA(lt).

From being parsed correctly.

This change updates the `cast` constant in sql_function.ts to use `altPrio(SQLCase, SQLFunctionInput)`, allowing either a CASE expression or a regular function input inside CAST. Two new test cases are added in the SELECT statement tests to cover both simple and correlated CASE expressions inside CAST.