### PR TITLE
ABAP SQL parser: minor improvements

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/_select_core.ts
+++ b/packages/core/src/abap/2_statements/expressions/_select_core.ts
@@ -45,30 +45,32 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
     ));
   }
 
-  const fromPackSize = seq(optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, optPrio(DatabaseConnection));
+  const fromPackSize = seq(optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, optPrio(DatabaseConnection), optPrio(SQLUpTo));
 
   const trailingInto = seq(
-    optPrio(seq(intoForPackSize, optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, optPrio(SQLOrderBy), optPrio(SQLOptions))),
-    optPrio(seq(intoSingle, optPrio(SQLUpTo), byp, optPrio(SQLOptions))),
+    optPrio(seq(intoForPackSize, optPrio(SQLPackageSize), byp, optPrio(SQLUpTo), byp,
+                optPrio(offset), optPrio(SQLOrderBy), optPrio(SQLOptions))),
+    optPrio(seq(intoSingle, byp, optPrio(SQLUpTo), byp, optPrio(offset), optPrio(SQLOptions))),
   );
 
   const afterFromWithInto = seq(
     optPrio(SQLFrom), client, byp, fromPackSize,
     altPrio(
       seq(sqlFields, fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, trailingInto),
-      seq(intoForPackSize, optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, fae,
-          whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
-      seq(intoSingle, byp, fae, optPrio(SQLUpTo), byp, whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
+      seq(intoForPackSize, optPrio(SQLPackageSize), byp, optPrio(DatabaseConnection),
+          optPrio(SQLUpTo), byp, optPrio(offset), fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
+      seq(intoSingle, byp, optPrio(SQLUpTo), byp, fae, optPrio(SQLUpTo), byp,
+          optPrio(offset), whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
       seq(fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, trailingInto),
     ),
   );
 
   const selectTableIntoThenFrom = seq(
-    intoForPackSize, optPrio(SQLPackageSize), optPrio(SQLUpTo),
+    intoForPackSize, optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, optPrio(DatabaseConnection),
     afterFromWithInto,
   );
   const selectOtherIntoThenFrom = seq(
-    intoAny, optPrio(SQLUpTo), byp,
+    intoAny, optPrio(SQLUpTo), byp, optPrio(DatabaseConnection),
     afterFromWithInto,
   );
 
@@ -76,14 +78,14 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
                             altPrio(selectTableIntoThenFrom, selectOtherIntoThenFrom, afterFromWithInto));
 
   const singleAfterFrom = seq(
-    SQLFrom, client, byp,
+    SQLFrom, client, byp, optPrio(DatabaseConnection),
     altPrio(
-      seq(sqlFields, whereClause, groupHaving, trailingOpts, optPrio(intoSingle)),
+      seq(sqlFields, whereClause, groupHaving, trailingOpts, optPrio(intoSingle), optPrio(DatabaseConnection)),
       seq(intoSingle, byp, whereClause, groupHaving, trailingOpts),
-      seq(whereClause, groupHaving, trailingOpts, optPrio(intoSingle)),
+      seq(whereClause, groupHaving, trailingOpts, optPrio(intoSingle), optPrio(DatabaseConnection)),
     ),
   );
-  const singleIntoBeforeFrom = seq(intoSingle, SQLFrom, client, byp, whereClause, groupHaving, trailingOpts);
+  const singleIntoBeforeFrom = seq(intoSingle, SQLFrom, client, byp, optPrio(DatabaseConnection), whereClause, groupHaving, trailingOpts);
 
   return seq("SELECT", altPrio(
     seq("SINGLE", optPrio("FOR UPDATE"), fieldList, byp, altPrio(singleIntoBeforeFrom, singleAfterFrom)),

--- a/packages/core/src/abap/2_statements/expressions/field_length.ts
+++ b/packages/core/src/abap/2_statements/expressions/field_length.ts
@@ -1,5 +1,5 @@
 import {seq, optPrio, altPrio, tok, regex as reg, Expression} from "../combi";
-import {ParenLeft, ParenRightW, Plus} from "../../1_lexer/tokens";
+import {ParenLeft, ParenRightW, ParenRight, Plus} from "../../1_lexer/tokens";
 import {SimpleFieldChain2} from ".";
 import {IStatementRunnable} from "../statement_runnable";
 
@@ -10,7 +10,7 @@ export class FieldLength extends Expression {
 
     const length = seq(tok(ParenLeft),
                        optPrio(altPrio(normal, "*")),
-                       tok(ParenRightW));
+                       altPrio(tok(ParenRightW), tok(ParenRight)));
 
     return length;
   }

--- a/packages/core/src/abap/2_statements/expressions/index.ts
+++ b/packages/core/src/abap/2_statements/expressions/index.ts
@@ -190,6 +190,7 @@ export * from "./sql_into_structure";
 export * from "./sql_field_list_loop_greedy";
 export * from "./sql_into_table";
 export * from "./sql_join";
+export * from "./sql_join_source";
 export * from "./sql_options";
 export * from "./sql_package_size";
 export * from "./sql_order_by";

--- a/packages/core/src/abap/2_statements/expressions/sql_case.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_case.ts
@@ -19,11 +19,12 @@ export class SQLCase extends Expression {
                           Constant);
     const sub = seq(altPrio("+", "-", "*", "/", "&&"), optPrio(tok(WParenLeftW)), field, optPrio(tok(WParenRightW)));
 
-    const sourc = altPrio(SQLCase, SQLAggregation, SQLFunction, SQLFieldName, SQLSource, Constant);
+    const source = altPrio(SQLCase, SQLAggregation, SQLFunction, SQLFieldName, SQLSource, Constant);
+    const parenSource = seq(tok(WParenLeftW), source, tok(WParenRightW));
     const val = altPrio(SQLCond, Constant, abap);
-    const when = seq("WHEN", val, "THEN", sourc, starPrio(sub));
-    const els = seq("ELSE", sourc);
+    const when = seq("WHEN", val, "THEN", altPrio(parenSource, seq(optPrio("-"), source)), starPrio(sub));
+    const else_ = seq("ELSE", altPrio(parenSource, seq(optPrio("-"), source)));
 
-    return ver(Version.v740sp05, seq("CASE", opt(altPrio(SQLFieldName, abap)), plusPrio(when), optPrio(els), "END"), Version.OpenABAP);
+    return ver(Version.v740sp05, seq("CASE", opt(altPrio(SQLFieldName, abap)), plusPrio(when), optPrio(else_), "END"), Version.OpenABAP);
   }
 }

--- a/packages/core/src/abap/2_statements/expressions/sql_client.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_client.ts
@@ -1,12 +1,15 @@
 import {Version} from "../../../version";
-import {alt, seq, Expression, ver, verNot} from "../combi";
+import {alt, seq, Expression, ver, verNot, optPrio, starPrio} from "../combi";
 import {IStatementRunnable} from "../statement_runnable";
 import {SQLSourceSimple} from "./sql_source_simple";
+import {SQLAliasField} from "./sql_alias_field";
+import {Dynamic} from "./dynamic";
 
 export class SQLClient extends Expression {
   public getRunnable(): IStatementRunnable {
+    const clientList = ver(Version.v740sp05, alt(Dynamic, seq(SQLAliasField, starPrio(seq(",", SQLAliasField)))));
 
-    const client = alt(verNot(Version.Cloud, "CLIENT SPECIFIED"),
+    const client = alt(verNot(Version.Cloud, seq("CLIENT SPECIFIED", optPrio(clientList))),
                        seq("USING", alt(ver(Version.v740sp05, seq("CLIENT", SQLSourceSimple)),
                                         ver(Version.v754, seq("CLIENTS IN", alt(SQLSourceSimple, "T000"))),
                                         ver(Version.v754, "ALL CLIENTS"))));

--- a/packages/core/src/abap/2_statements/expressions/sql_field.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_field.ts
@@ -29,18 +29,16 @@ export class SQLField extends Expression {
     const parenField = seq(tok(WParenLeftW), field, tok(WParenRightW));
     const parenFieldNoAgg = seq(tok(WParenLeftW), fieldNoAgg, tok(WParenRightW));
 
-    // without aggregates: from v740sp05
     const subNoAgg = plusPrio(seq(altPrio("+", "-", "*", "/", "&&"), altPrio(parenFieldNoAgg, fieldNoAgg)));
     const arithNoAgg = ver(Version.v740sp05, subNoAgg);
 
-    // with aggregates: from v754
     const subWithAgg = plusPrio(seq(altPrio("+", "-", "*", "/", "&&"), altPrio(parenField, field)));
     const arithWithAgg = ver(Version.v754, subWithAgg);
 
     const arith = altPrio(arithWithAgg, arithNoAgg);
 
-    const arithSequence = seq(field, optPrio(arith));
-    const parenArithSequence = seq(tok(WParenLeftW), arithSequence, tok(WParenRightW));
+    const arithSequence = seq(optPrio("-"), field, optPrio(arith));
+    const parenArithSequence = seq(tok(WParenLeftW), optPrio("-"), arithSequence, tok(WParenRightW));
 
     // allows (a-b)*(c-d) — paren groups as operands, defined after parenArithSequence
     const subExtWithAgg = plusPrio(seq(altPrio("+", "-", "*", "/", "&&"), altPrio(parenArithSequence, parenField, field)));

--- a/packages/core/src/abap/2_statements/expressions/sql_group_by.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_group_by.ts
@@ -1,13 +1,22 @@
-import {Expression, seq, plus, alt, altPrio} from "../combi";
+import {Expression, seq, plus, alt, altPrio, ver, optPrio} from "../combi";
+import {Version} from "../../../version";
 import {IStatementRunnable} from "../statement_runnable";
 import {Dynamic} from "./dynamic";
 import {SQLFieldName} from "./sql_field_name";
+import {SQLField} from "./sql_field";
 
 export class SQLGroupBy extends Expression {
   public getRunnable(): IStatementRunnable {
-    const f = alt(SQLFieldName, Dynamic);
-    const strict = seq(plus(seq(f, ",")), f);
-    const group = seq("GROUP BY", altPrio(strict, plus(f)));
-    return group;
+    const fieldName = alt(SQLFieldName, Dynamic);
+
+    const expr = ver(Version.v740sp02, SQLField, Version.OpenABAP);
+    const newGroup = ver(Version.v740sp02,
+                         seq("GROUP BY", expr, altPrio(plus(seq(",", expr)), optPrio(plus(fieldName)))),
+                         Version.OpenABAP);
+
+    const old = seq(plus(seq(fieldName, ",")), fieldName);
+    const oldGroup = seq("GROUP BY", altPrio(old, plus(fieldName)));
+
+    return altPrio(newGroup, oldGroup);
   }
 }

--- a/packages/core/src/abap/2_statements/expressions/sql_hints.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_hints.ts
@@ -1,11 +1,11 @@
-import {seq, plus, Expression, altPrio, alt} from "../combi";
-import {Constant, FieldSub} from ".";
+import {seq, plus, Expression, altPrio} from "../combi";
+import {SQLSource} from "./sql_source";
 import {IStatementRunnable} from "../statement_runnable";
 
 export class SQLHints extends Expression {
   public getRunnable(): IStatementRunnable {
     const type = altPrio("ORACLE", "ADABAS", "AS400", "DB2", "HDB", "MSSQLNT", "SYBASE", "DB6", "INFORMIX");
-    const ret = seq("%_HINTS", plus(seq(type, alt(Constant, FieldSub))));
+    const ret = seq("%_HINTS", plus(seq(type, SQLSource)));
     return ret;
   }
 }

--- a/packages/core/src/abap/2_statements/expressions/sql_join.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_join.ts
@@ -1,15 +1,16 @@
 import {seq, optPrio, altPrio, Expression, ver} from "../combi";
-import {SQLFromSource, SQLCond} from ".";
+import {SQLCond} from ".";
 import {IStatementRunnable} from "../statement_runnable";
 import {Version} from "../../../version";
+import {SQLJoinSource} from "./sql_join_source";
 
 export class SQLJoin extends Expression {
   public getRunnable(): IStatementRunnable {
     const joinType = seq(optPrio(altPrio("INNER", "LEFT OUTER", "LEFT", "RIGHT OUTER", "RIGHT")), "JOIN");
 
-    const join = seq(joinType, SQLFromSource, "ON", SQLCond);
+    const join = seq(joinType, new SQLJoinSource(), "ON", SQLCond);
 
-    const crossJoin = ver(Version.v750, seq("CROSS JOIN", SQLFromSource), Version.OpenABAP);
+    const crossJoin = ver(Version.v750, seq("CROSS JOIN", new SQLJoinSource()), Version.OpenABAP);
 
     return altPrio(crossJoin, join);
   }

--- a/packages/core/src/abap/2_statements/expressions/sql_join_source.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_join_source.ts
@@ -1,0 +1,17 @@
+import {seq, optPrio, altPrio, Expression, tok, starPrio} from "../combi";
+import {SQLFromSource} from ".";
+import {WParenLeftW, WParenRightW} from "../../1_lexer/tokens";
+import {IStatementRunnable} from "../statement_runnable";
+import {SQLJoin} from "./sql_join";
+
+export class SQLJoinSource extends Expression {
+  public getRunnable(): IStatementRunnable {
+    const paren = seq(
+      tok(WParenLeftW),
+      altPrio(new SQLJoinSource(), SQLFromSource),
+      starPrio(seq(optPrio(tok(WParenRightW)), new SQLJoin())),
+      optPrio(tok(WParenRightW)),
+    );
+    return altPrio(paren, SQLFromSource);
+  }
+}

--- a/packages/core/test/abap/statements/select.ts
+++ b/packages/core/test/abap/statements/select.ts
@@ -28,6 +28,8 @@ const tests = [
   "SELECT COUNT(*) FROM /bobf/act_conf WHERE name = 'ZFOO'.",
   "SELECT * FROM zfoobar CLIENT SPECIFIED INTO TABLE rt_data WHERE mandt = '111'.",
   "SELECT SINGLE FOR UPDATE * FROM ZFOOBAR WHERE NAME_ID = lv_name.",
+  "SELECT SINGLE FOR UPDATE * FROM ztab WHERE k = @lv INTO @DATA(lv) CONNECTION (lv_con).",
+  "SELECT SINGLE FOR UPDATE * FROM ztab WHERE k = @lv INTO @lv2 CONNECTION (lv_con).",
   "SELECT * FROM zfoo BYPASSING BUFFER INTO TABLE lt_table WHERE foo = lv_bar.",
   "SELECT SINGLE MAX( version ) FROM zfoo INTO lv_version.",
   "SELECT SINGLE MAX( version ) FROM zfoo INTO lv_version BYPASSING BUFFER WHERE " +
@@ -136,6 +138,10 @@ const tests = [
   "SELECT * FROM table INTO TABLE lt_tab WHERE field LIKE search ESCAPE '#'.",
   "SELECT * FROM table INTO TABLE lt_tab %_HINTS ORACLE 'FIRST_ROWS'.",
   "SELECT foo INTO TABLE gt_result FROM ztable %_HINTS ORACLE 'ORDERED' ORACLE 'USE_NL(&table2&)'.",
+  "SELECT * FROM ztab INTO TABLE @DATA(lt_r) %_HINTS HDB @lv_hint DB2 @lv_hint ORACLE @lv_hint.",
+  "SELECT * FROM ztab INTO TABLE @DATA(lt_r) %_HINTS HDB lv_hint DB2 lv_hint.",
+  "SELECT * FROM ztab INTO TABLE @DATA(lt_r) %_HINTS HDB '&prefer_join 0&' HDB '&prefer_union_all 1&'.",
+  "SELECT * FROM ztab INTO TABLE @DATA(lt_r) %_HINTS ADABAS go_hints->adabas AS400 go_hints->as400 HDB go_hints->hdb.",
   "SELECT SINGLE FROM table FIELDS field INTO @DATA(lv_field).",
   "SELECT SINGLE @abap_true FROM dd03l INTO @DATA(lv_exists) WHERE tabname = @lv_tabname AND as4local = 'A'.",
   "SELECT field1, field2 FROM ztab INTO TABLE @DATA(lt_result) WHERE field = @lv_field ORDER BY field1, field2.",
@@ -164,6 +170,15 @@ const tests = [
   "SELECT SINGLE * FROM ztable WHERE host = @lv_host INTO @DATA(ls_config).",
   "SELECT SINGLE * FROM ztable WHERE lower( host ) = @lv_host INTO @DATA(ls_config).",
   "SELECT bname, bcode FROM usr02 GROUP BY bname, bcode INTO TABLE @DATA(result).",
+  `SELECT f FROM t1 INNER JOIN ( t2 ) ON t1~k = t2~k INTO TABLE @DATA(lt_r).`,
+  `SELECT f FROM t1 INNER JOIN ( t2 AS x ) ON t1~k = x~k INTO TABLE @DATA(lt_r).`,
+  `SELECT f FROM t1 LEFT OUTER JOIN ( t2 LEFT JOIN t3 ON t2~k = t3~k ) ON t1~k = t2~k INTO TABLE @DATA(lt_r).`,
+  `SELECT f FROM t1 LEFT OUTER JOIN ( ( t2 INNER JOIN t3 ON t2~k = t3~k ) LEFT JOIN t4 ON t3~k = t4~k ) ON t1~k = t2~k INTO TABLE @DATA(lt_r).`,
+  `SELECT f FROM t1 WHERE f IN ( SELECT f FROM t1 JOIN ( t2 JOIN t3 ON t2~k = t3~k ) ON t1~k = t2~k ) INTO TABLE @DATA(lt_r).`,
+  `SELECT f INTO TABLE @lt CONNECTION (lv_con) FROM t1.`,
+  `SELECT f INTO TABLE @lt CONNECTION (lv_con) FROM ( t1 JOIN t2 ON t1~k = t2~k ).`,
+  `SELECT f INTO CORRESPONDING FIELDS OF TABLE @lt CONNECTION (lv_con) FROM ( ( ( t1 JOIN t2 ON t1~k = t2~k ) LEFT OUTER JOIN t3 ON t1~k = t3~k ) LEFT OUTER JOIN t4 ON t1~k = t4~k ) WHERE lv = lv2.`,
+  `SELECT f FROM ( t1 INNER JOIN t2 ON t1~k = t2~k ) INTO TABLE @lt CONNECTION (lv_con) WHERE k = @lv.`,
 
   `SELECT *
 FROM /abc/def_c_clearing_history(
@@ -429,6 +444,9 @@ WHERE  but000~partner IN ('1000' , '2000' , '3000' ).`,
 
   `SELECT SINGLE (lv_fields) FROM ztab GROUP BY (lv_grp) HAVING (lv_having) INTO @wa.`,
 
+  `SELECT SINGLE MAX( col ) INTO @wa FROM ztab CONNECTION (lv_con) WHERE col = @lv HAVING MAX( col ) IS NOT NULL.`,
+  `SELECT SINGLE col INTO @lv FROM ztab CONNECTION (lv_con) WHERE col = @lv.`,
+
   `SELECT SINGLE * FROM t100 WHERE 'A' = t100~arbgb INTO @DATA(sdf).`,
 
   `SELECT
@@ -524,6 +542,11 @@ WHERE  but000~partner IN ('1000' , '2000' , '3000' ).`,
   `SELECT ( arbgb ) FROM t100 INTO TABLE @DATA(sdf).`,
   `SELECT ( arbgb ) AS bar FROM t100 INTO TABLE @DATA(sdf).`,
   `SELECT ( arbgb ), text AS bar FROM t100 INTO TABLE @DATA(sdf).`,
+  `SELECT (lv_dyn(11)) FROM t100 INTO TABLE @DATA(sdf).`,
+  `SELECT (lv_dyn+3(1)) FROM t100 INTO TABLE @DATA(sdf).`,
+  `SELECT (lv_dyn+lv_off(lv_len)) FROM t100 INTO TABLE @DATA(sdf).`,
+  `SELECT (go_obj->attr) FROM t100 INTO TABLE @DATA(sdf).`,
+  `SELECT (ls_str-(lv_comp)) FROM t100 INTO TABLE @DATA(sdf).`,
   `SELECT DISTINCT 'I' AS sign, 'EQ' AS option, werks AS low
     FROM t001w
     APPENDING CORRESPONDING FIELDS OF TABLE @r_drive[]
@@ -574,6 +597,11 @@ WHERE  but000~partner IN ('1000' , '2000' , '3000' ).`,
   `SELECT CAST( CASE T1~_DATAAGING WHEN '00000000' THEN ' ' ELSE 'X' END AS CHAR ) AS XARCH FROM BSEG AS T1 INTO TABLE @DATA(lt_result).`,
   `SELECT CAST( CASE T1~FKBER_LONG WHEN ' ' THEN T1~FKBER ELSE T1~FKBER_LONG END AS CHAR ) AS FKBER ` +
   ` FROM BSEG AS T1 INTO TABLE @DATA(lt_result).`,
+  `SELECT CASE col WHEN @abap_true THEN ( ' ' ) ELSE ( 'X' ) END AS flag FROM ztab INTO TABLE @DATA(lt_r).`,
+  `SELECT CASE col WHEN '1' THEN ( 'Y' ) WHEN '0' THEN ( 'N' ) ELSE ( ' ' ) END AS val FROM ztab INTO TABLE @DATA(lt_r).`,
+  `SELECT @class_name=>const_attr AS rec FROM ztab INTO TABLE @DATA(lt_r).`,
+  `SELECT col FROM ztab WHERE col = @class_name=>const_attr INTO TABLE @DATA(lt_r).`,
+  `SELECT col FROM ztab WHERE NOT col LIKE '/prefix_pattern' INTO TABLE @DATA(lt_r).`,
 ];
 
 statementType(tests, "SELECT", Statements.Select);
@@ -594,6 +622,12 @@ statementType([
   `SELECT * FROM ztab UP TO 10 ROWS BYPASSING BUFFER INTO TABLE @DATA(lt_r).`,
   `SELECT * FROM ztab UP TO 10 ROWS BYPASSING BUFFER WHERE col = @lv_v INTO TABLE @DATA(lt_r).`,
   `SELECT * FROM ztab CLIENT SPECIFIED BYPASSING BUFFER UP TO 10 ROWS WHERE col = @lv_v INTO TABLE @DATA(lt_r).`,
+  `SELECT * UP TO 10 ROWS INTO TABLE @DATA(lt_r) BYPASSING BUFFER FROM ztab WHERE col = @lv_v.`,
+  `SELECT * UP TO 10 ROWS APPENDING CORRESPONDING FIELDS OF TABLE @lt_r BYPASSING BUFFER FROM ztab WHERE col = @lv_v.`,
+  `SELECT * INTO CORRESPONDING FIELDS OF TABLE @lt_r BYPASSING BUFFER FROM ztab INNER JOIN ztab2 ON ztab~k = ztab2~k WHERE ztab~col = @lv_v.`,
+  `SELECT col INTO CORRESPONDING FIELDS OF TABLE @lt_r BYPASSING BUFFER FROM ztab FOR ALL ENTRIES IN @lt_fae WHERE col = @lt_fae-col.`,
+  `SELECT * FROM ztab CONNECTION (lv_con) UP TO 10 ROWS INTO TABLE @DATA(lt_r) BYPASSING BUFFER WHERE col = @lv_v.`,
+  `SELECT * FROM ztab CONNECTION (lv_con) UP TO 10 ROWS APPENDING CORRESPONDING FIELDS OF TABLE @lt_r BYPASSING BUFFER WHERE col = @lv_v.`,
 ], "SELECT BYPASSING BUFFER positional variants", Statements.Select);
 
 const versions = [
@@ -612,6 +646,16 @@ const versions = [
   {abap: `SELECT t1~field1, t1~field2, division( t1~field3, t2~field3, 2 ) AS ratio FROM ztable AS t1 INNER JOIN ztable2 AS t2 ON t1~field1 = t2~field1 ORDER BY t1~field1 INTO TABLE @DATA(result).`, ver: Version.v751},
   {abap: `SELECT t1~field1, division( t1~field2, t2~field2, 2 ) AS d FROM ztable AS t1 LEFT OUTER JOIN ztable2 AS t2 ON t1~field1 = t2~field1 WHERE division( t1~field2, t2~field2, 2 ) IS NOT NULL INTO TABLE @DATA(result).`, ver: Version.v751},
   {abap: `SELECT t1~field1, division( t1~field2, t2~field2, 2 ) AS d FROM ztable AS t1 LEFT OUTER JOIN ztable2 AS t2 ON t1~field1 = t2~field1 WHERE division( t1~field2, t2~field2, 2 ) IS NULL INTO TABLE @DATA(result).`, ver: Version.v751},
+  {abap: `SELECT col FROM ztab USING CLIENT @lv_mandt INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT col FROM ztab ORDER BY col INTO TABLE @DATA(lt_r) UP TO 10 ROWS OFFSET @lv_off.`, ver: Version.v751},
+  {abap: `SELECT col1 + col2 AS first , COUNT(*) AS second FROM ztab GROUP BY col1 + col2 ORDER BY first INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT - col AS neg , COUNT(*) AS cnt FROM ztab GROUP BY - col INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT CASE WHEN col = 0 THEN 0 WHEN col IS NOT NULL THEN 1 END AS grp , COUNT(*) FROM ztab GROUP BY CASE WHEN col = 0 THEN 0 WHEN col IS NOT NULL THEN 1 END INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT 1 + CASE WHEN col < 2 THEN 1 END AS grp , COUNT(*) FROM ztab GROUP BY 1 + CASE WHEN col < 2 THEN 1 END INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT col FROM ztab GROUP BY REPLACE( CONCAT( col , col2 ) , col3 , col4 ) INTO TABLE @DATA(lt_r).`, ver: Version.v750},
+  {abap: `SELECT col1 + col2 AS first , col3 , COUNT(*) AS cnt FROM ztab GROUP BY col1 + col2 , col3 INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT - col AS neg , col2 , COUNT(*) AS cnt FROM ztab GROUP BY - col , col2 INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT @lv_const AS c , col , COUNT(*) AS cnt FROM ztab GROUP BY @lv_const , col INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
 ];
 
 statementVersion(versions, "SELECT", Statements.Select);
@@ -696,6 +740,8 @@ const aggArgExprVersions = [
   {abap: `SELECT SINGLE COUNT( DISTINCT field1 + field2 ) FROM ztable INTO @DATA(result).`, ver: Version.v740sp08},
   {abap: `SELECT SINGLE SUM( field1 + @lv_offset ) FROM ztable INTO @DATA(result).`, ver: Version.v740sp08},
   {abap: `SELECT SINGLE SUM( CASE WHEN field1 > 0 THEN field1 ELSE 0 END ) FROM ztable INTO @DATA(result).`, ver: Version.v740sp08},
+  {abap: `SELECT SINGLE SUM( CASE WHEN field1 > 0 THEN field1 ELSE - field1 END ) FROM ztable INTO @DATA(result).`, ver: Version.v740sp08},
+  {abap: `SELECT - col AS neg , col FROM ztab INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
 ];
 
 statementVersionOk(aggArgExprVersions, "SELECT", Statements.Select);
@@ -847,6 +893,19 @@ const unionClientVersions = [
 
 statementType(unionClientVersions, "SELECT UNION CLIENT SPECIFIED / USING CLIENT / dynamic", Statements.Select);
 
+statementVersion([
+  {abap: `SELECT * FROM ztab CLIENT SPECIFIED t~mandt INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT * FROM ztab CLIENT SPECIFIED t~mandt WHERE col = @lv_v INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT * FROM ztab INNER JOIN ztab2 ON ztab~k = ztab2~k CLIENT SPECIFIED ztab~mandt , ztab2~mandt INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+  {abap: `SELECT * FROM ('ztab') CLIENT SPECIFIED (lv_cl) INTO CORRESPONDING FIELDS OF TABLE @lt_r.`, ver: Version.v740sp05},
+  {abap: `SELECT * FROM ztab CLIENT SPECIFIED (lv_cl) WHERE col = @lv_v INTO TABLE @DATA(lt_r).`, ver: Version.v740sp05},
+], "SELECT CLIENT SPECIFIED with column list or dynamic", Statements.Select);
+
+statementVersionFail([
+  {abap: `SELECT * FROM ztab CLIENT SPECIFIED t~mandt INTO TABLE @DATA(lt_r).`, ver: Version.v740sp02},
+  {abap: `SELECT * FROM ztab CLIENT SPECIFIED (lv_cl) INTO TABLE @DATA(lt_r).`, ver: Version.v740sp02},
+], "SELECT CLIENT SPECIFIED column list requires v740sp05");
+
 const unionCorrespVersions = [
   `SELECT f1 FROM ztab UNION SELECT f1 FROM ztab INTO CORRESPONDING FIELDS OF @wa.`,
   `SELECT f1 FROM ztab UNION SELECT f1 FROM ('ztab') INTO CORRESPONDING FIELDS OF @wa.`,
@@ -855,6 +914,18 @@ const unionCorrespVersions = [
 ];
 
 statementType(unionCorrespVersions, "SELECT UNION into corresponding fields", Statements.SelectLoop);
+
+statementType([
+  `SELECT * FROM ztab INTO wa UP TO 5 ROWS FOR ALL ENTRIES IN lt WHERE col = lt-col.`,
+  `SELECT * FROM ztab INTO wa UP TO lv_n ROWS FOR ALL ENTRIES IN lt WHERE col = lt-col.`,
+  `SELECT * FROM ztab INNER JOIN ztab2 ON ztab~k EQ ztab2~k INTO wa UP TO lv_n ROWS FOR ALL ENTRIES IN lt WHERE ztab~k EQ lt-k.`,
+], "SELECT INTO structure UP TO ROWS FOR ALL ENTRIES", Statements.SelectLoop);
+
+statementVersion([
+  {abap: `SELECT col FROM ztab ORDER BY col INTO @DATA(lv_r) UP TO 1 ROWS OFFSET 5.`, ver: Version.v751},
+  {abap: `SELECT col FROM ztab ORDER BY (lv_dyn) INTO @DATA(lv_r) UP TO 1 ROWS OFFSET 5.`, ver: Version.v751},
+  {abap: `SELECT col FROM ztab ORDER BY col INTO TABLE @DATA(lt_r) PACKAGE SIZE 17 UP TO 1 ROWS OFFSET 2.`, ver: Version.v751},
+], "SELECT OFFSET after INTO UP TO", Statements.SelectLoop);
 
 statementType([
   `WITH +cte AS ( SELECT col FROM ztab ) SELECT FROM +cte FIELDS col INTO TABLE @DATA(lt_r).`,


### PR DESCRIPTION
- BYPASSING BUFFER in all positional variants
- CLIENT SPECIFIED with column list / dynamic
- GROUP BY arbitrary expressions
- Unary minus in field list and CASE THEN/ELSE
- OFFSET after INTO UP TO
- %_HINTS accepts host variables and field chains
- Multiple db hints for the same db vendor
- Dynamic field offset/length notation inside Dynamic
- Parenthesized THEN/ELSE values in CASE
- CONNECTION in all INTO-before-FROM and SINGLE positions
- INTO wa UP TO N ROWS FOR ALL ENTRIES ordering
- Arbitrary nesting of JOINs