### PR TITLE
simplify SELECT

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/_select_core.ts
+++ b/packages/core/src/abap/2_statements/expressions/_select_core.ts
@@ -57,9 +57,9 @@ export function buildSelectCore(allowInto = false, allowOrderBy = true): IStatem
     altPrio(
       seq(sqlFields, fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, trailingInto),
       seq(intoForPackSize, optPrio(SQLPackageSize), byp, optPrio(DatabaseConnection),
-          optPrio(SQLUpTo), byp, optPrio(offset), fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
+          optPrio(SQLUpTo), byp, optPrio(offset), fae, whereClause, groupHaving, ...orderUpOff, trailingOpts),
       seq(intoSingle, byp, optPrio(SQLUpTo), byp, fae, optPrio(SQLUpTo), byp,
-          optPrio(offset), whereClause, groupHaving, ...orderUpOff, trailingOpts, optPrio(SQLOptions)),
+          optPrio(offset), whereClause, groupHaving, ...orderUpOff, trailingOpts),
       seq(fae, whereClause, groupHaving, ...orderUpOff, trailingOpts, trailingInto),
     ),
   );

--- a/packages/core/src/abap/2_statements/expressions/_select_core.ts
+++ b/packages/core/src/abap/2_statements/expressions/_select_core.ts
@@ -39,10 +39,10 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
       ),
     );
     const singleBody = seq(SQLFrom, client, byp, whereClause, groupHaving, trailingOpts);
-    return seq("SELECT", altPrio(
+    return altPrio(
       seq("SINGLE", optPrio("FOR UPDATE"), fieldList, singleBody),
       seq(optPrio("DISTINCT"), fieldList, byp, afterFromNoInto),
-    ));
+    );
   }
 
   const fromPackSize = seq(optPrio(SQLPackageSize), optPrio(SQLUpTo), byp, optPrio(DatabaseConnection), optPrio(SQLUpTo));
@@ -87,8 +87,8 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
   );
   const singleIntoBeforeFrom = seq(intoSingle, SQLFrom, client, byp, optPrio(DatabaseConnection), whereClause, groupHaving, trailingOpts);
 
-  return seq("SELECT", altPrio(
+  return altPrio(
     seq("SINGLE", optPrio("FOR UPDATE"), fieldList, byp, altPrio(singleIntoBeforeFrom, singleAfterFrom)),
     nonSingleBody,
-  ));
+  );
 }

--- a/packages/core/src/abap/2_statements/expressions/_select_core.ts
+++ b/packages/core/src/abap/2_statements/expressions/_select_core.ts
@@ -9,7 +9,7 @@ import {SQLGroupBy} from "./sql_group_by";
 import {SQLIntoStructure} from "./sql_into_structure";
 import {SQLUpTo} from "./sql_up_to";
 
-export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true): IStatementRunnable {
+export function buildSelectCore(allowInto = false, allowOrderBy = true): IStatementRunnable {
   const where = seq("WHERE", SQLCond);
   const offset = ver(Version.v751, seq("OFFSET", SQLSource));
   const sqlFields = ver(Version.v750, SQLFields, Version.OpenABAP);
@@ -27,10 +27,9 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
   const trailingOpts = seq(optPrio(DatabaseConnection), optPrio(SQLHints), optPrio(privileged), optPrio(SQLOptions));
 
   const intoSingle = altPrio(SQLIntoStructure, SQLIntoList);
-  const intoAny = into ? altPrio(into, intoSingle) : intoSingle;
   const intoForPackSize = SQLIntoTable;
 
-  if (!into) {
+  if (!allowInto) {
     const afterFromNoInto = seq(
       SQLFrom, client, byp,
       altPrio(
@@ -70,7 +69,7 @@ export function buildSelectCore(into?: IStatementRunnable, allowOrderBy = true):
     afterFromWithInto,
   );
   const selectOtherIntoThenFrom = seq(
-    intoAny, optPrio(SQLUpTo), byp, optPrio(DatabaseConnection),
+    intoSingle, optPrio(SQLUpTo), byp, optPrio(DatabaseConnection),
     afterFromWithInto,
   );
 

--- a/packages/core/src/abap/2_statements/expressions/select.ts
+++ b/packages/core/src/abap/2_statements/expressions/select.ts
@@ -12,7 +12,7 @@ export class Select extends Expression {
     const standalone = buildSelectCore(true);
 
     const unionTail = ver(Version.v750, plusPrio(SQLSetOp), Version.OpenABAP);
-    const chained = seq(buildSelectCore(undefined, false), unionTail, optPrio(SQLOrderBy), optPrio(into));
+    const chained = seq(buildSelectCore(false, false), unionTail, optPrio(SQLOrderBy), optPrio(into));
 
     return seq("SELECT", altPrio(chained, standalone));
   }

--- a/packages/core/src/abap/2_statements/expressions/select.ts
+++ b/packages/core/src/abap/2_statements/expressions/select.ts
@@ -14,6 +14,6 @@ export class Select extends Expression {
     const unionTail = ver(Version.v750, plusPrio(SQLSetOp), Version.OpenABAP);
     const chained = seq(buildSelectCore(undefined, false), unionTail, optPrio(SQLOrderBy), optPrio(into));
 
-    return altPrio(chained, standalone);
+    return seq("SELECT", altPrio(chained, standalone));
   }
 }

--- a/packages/core/src/abap/2_statements/expressions/select.ts
+++ b/packages/core/src/abap/2_statements/expressions/select.ts
@@ -9,7 +9,7 @@ export class Select extends Expression {
   public getRunnable(): IStatementRunnable {
     const into = altPrio(SQLIntoTable, SQLIntoStructure, SQLIntoList);
 
-    const standalone = buildSelectCore(into);
+    const standalone = buildSelectCore(true);
 
     const unionTail = ver(Version.v750, plusPrio(SQLSetOp), Version.OpenABAP);
     const chained = seq(buildSelectCore(undefined, false), unionTail, optPrio(SQLOrderBy), optPrio(into));

--- a/packages/core/src/abap/2_statements/expressions/sql_set_op.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_set_op.ts
@@ -6,7 +6,7 @@ import {buildSelectCore} from "./_select_core";
 
 export class SQLSetOp extends Expression {
   public getRunnable(): IStatementRunnable {
-    const operand = altPrio(SQLSetOpGroup, buildSelectCore(undefined, false));
+    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(undefined, false)));
 
     const union = seq("UNION", optPrio(altPrio("DISTINCT", "ALL")));
     const intersectExcept = altPrio(seq("INTERSECT", optPrio("DISTINCT")),

--- a/packages/core/src/abap/2_statements/expressions/sql_set_op.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_set_op.ts
@@ -6,7 +6,7 @@ import {buildSelectCore} from "./_select_core";
 
 export class SQLSetOp extends Expression {
   public getRunnable(): IStatementRunnable {
-    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(undefined, false)));
+    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(false, false)));
 
     const union = seq("UNION", optPrio(altPrio("DISTINCT", "ALL")));
     const intersectExcept = altPrio(seq("INTERSECT", optPrio("DISTINCT")),

--- a/packages/core/src/abap/2_statements/expressions/sql_set_op_group.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_set_op_group.ts
@@ -6,7 +6,7 @@ import {buildSelectCore} from "./_select_core";
 
 export class SQLSetOpGroup extends Expression {
   public getRunnable(): IStatementRunnable {
-    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(undefined, false)));
+    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(false, false)));
     const chain = seq(operand, optPrio(seq(ver(Version.v750, plusPrio(SQLSetOp), Version.OpenABAP), optPrio(SQLOrderBy))));
 
     return ver(Version.v750, seq("(", chain, ")"), Version.OpenABAP);

--- a/packages/core/src/abap/2_statements/expressions/sql_set_op_group.ts
+++ b/packages/core/src/abap/2_statements/expressions/sql_set_op_group.ts
@@ -6,7 +6,7 @@ import {buildSelectCore} from "./_select_core";
 
 export class SQLSetOpGroup extends Expression {
   public getRunnable(): IStatementRunnable {
-    const operand = altPrio(SQLSetOpGroup, buildSelectCore(undefined, false));
+    const operand = altPrio(SQLSetOpGroup, seq("SELECT", buildSelectCore(undefined, false)));
     const chain = seq(operand, optPrio(seq(ver(Version.v750, plusPrio(SQLSetOp), Version.OpenABAP), optPrio(SQLOrderBy))));
 
     return ver(Version.v750, seq("(", chain, ")"), Version.OpenABAP);


### PR DESCRIPTION
currently a bit difficult to read: https://syntax.abaplint.org/?filter=select#/abap/expression/Select trying to simplify it a bit


start with one select, instead of two identical options

<img width="3051" height="222" alt="image" src="https://github.com/user-attachments/assets/3d25309f-cdac-44de-bd8a-03838d560d21" />

and fix this:

<img width="307" height="267" alt="image" src="https://github.com/user-attachments/assets/4f86fa48-6dc7-44e9-b9b7-3b27cff80699" />

and fix double options:

<img width="420" height="143" alt="image" src="https://github.com/user-attachments/assets/2ea6760b-73fd-4236-9368-f389c8243c63" />
