### PR TITLE
selection_screen_texts_missing: handle NO-DISPLAY and inline cases

### DIFF
--- a/packages/core/src/rules/selection_screen_texts_missing.ts
+++ b/packages/core/src/rules/selection_screen_texts_missing.ts
@@ -4,7 +4,7 @@ import {BasicRuleConfig} from "./_basic_rule_config";
 import {ITextElements} from "../objects/_abap_object";
 import {IObject} from "../objects/_iobject";
 import {IRegistry} from "../_iregistry";
-import {Parameter, SelectOption, Include} from "../abap/2_statements/statements";
+import {Parameter, SelectOption, Include, SelectionScreen} from "../abap/2_statements/statements";
 import {FieldSub, IncludeName} from "../abap/2_statements/expressions";
 import {Program} from "../objects";
 import {ABAPFile} from "../abap/abap_file";
@@ -22,6 +22,9 @@ export class SelectionScreenTextsMissing implements IRule {
       key: "selection_screen_texts_missing",
       title: "Selection screen texts missing",
       shortDescription: `Checks that selection screen parameters and select-options have selection texts`,
+      extendedInformation: `Excludes parameters and select-options that:
+* are inside a "SELECTION-SCREEN BEGIN OF LINE" block
+* have the addition "NO-DISPLAY"`,
     };
   }
 
@@ -67,31 +70,48 @@ export class SelectionScreenTextsMissing implements IRule {
     }
     checked.add(file.getFilename());
 
+    let inLine = false;
     for (const stat of file.getStatements()) {
       const s = stat.get();
-      if (s instanceof Parameter || s instanceof SelectOption) {
-        const fieldNode = stat.findFirstExpression(FieldSub);
-        if (fieldNode) {
-          const fieldName = fieldNode.getFirstToken().getStr().toUpperCase();
-          if (selTexts[fieldName] === undefined) {
-            const suffix = mainProgName ? `, ${mainProgName}` : ``;
-            output.push(Issue.atToken(
-              file,
-              fieldNode.getFirstToken(),
-              `Selection text missing for "${fieldName}"${suffix}`,
-              this.getMetadata().key,
-              this.conf.severity));
-          }
+      if (s instanceof SelectionScreen) {
+        const tokens = stat.concatTokens().toUpperCase();
+        if (tokens.includes("BEGIN OF LINE")) {
+          inLine = true;
+        } else if (tokens.includes("END OF LINE")) {
+          // known issue: doesn't support BEGIN and END OF LINE span across several includes (not seen a lot in the wild)
+          inLine = false;
         }
-      } else if (s instanceof Include) {
+        continue;
+      }
+      if (s instanceof Include) {
         const nameNode = stat.findFirstExpression(IncludeName);
         if (nameNode) {
           const inclName = nameNode.getFirstToken().getStr().toUpperCase();
           const inclObj = this.reg.getObject("PROG", inclName) as Program | undefined;
-          const inclMainProgName = mainProgName ?? file.getFilename();
           if (inclObj) {
-            this.checkFile(inclObj.getMainABAPFile(), selTexts, output, checked, inclMainProgName);
+            this.checkFile(inclObj.getMainABAPFile(), selTexts, output, checked, mainProgName ?? file.getFilename());
           }
+        }
+        continue;
+      }
+      if (inLine || !(s instanceof Parameter || s instanceof SelectOption)) {
+        continue;
+      }
+      if (stat.concatTokens().toUpperCase().includes("NO-DISPLAY")) {
+        continue;
+      }
+
+      const fieldNode = stat.findFirstExpression(FieldSub);
+      if (fieldNode) {
+        const fieldName = fieldNode.getFirstToken().getStr().toUpperCase();
+        if (selTexts[fieldName] === undefined) {
+          const suffix = mainProgName ? `, ${mainProgName}` : ``;
+          output.push(Issue.atToken(
+            file,
+            fieldNode.getFirstToken(),
+            `Selection text missing for "${fieldName}"${suffix}`,
+            this.getMetadata().key,
+            this.conf.severity));
         }
       }
     }

--- a/packages/core/test/rules/selection_screen_texts_missing.ts
+++ b/packages/core/test/rules/selection_screen_texts_missing.ts
@@ -309,4 +309,47 @@ PARAMETERS p_miss TYPE string.`;
     expect(issues[0].getMessage()).to.include(", zprog2.prog.abap");
   });
 
+  it("parameter with NO-DISPLAY, no issue", async () => {
+    const abap = `PARAMETERS p_miss TYPE string NO-DISPLAY.`;
+    const reg = new Registry();
+    reg.addFile(new MemoryFile("zfoobar.prog.abap", abap));
+    reg.addFile(new MemoryFile("zfoobar.prog.xml", xmlNoSelTexts));
+    const issues = await run(reg);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("select-option with NO-DISPLAY, no issue", async () => {
+    const abap = `DATA foo TYPE string.
+SELECT-OPTIONS s_miss FOR foo NO-DISPLAY.`;
+    const reg = new Registry();
+    reg.addFile(new MemoryFile("zfoobar.prog.abap", abap));
+    reg.addFile(new MemoryFile("zfoobar.prog.xml", xmlNoSelTexts));
+    const issues = await run(reg);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("parameter inside BEGIN OF LINE block, no issue", async () => {
+    const abap = `SELECTION-SCREEN BEGIN OF LINE.
+  PARAMETERS p_miss TYPE string.
+SELECTION-SCREEN END OF LINE.`;
+    const reg = new Registry();
+    reg.addFile(new MemoryFile("zfoobar.prog.abap", abap));
+    reg.addFile(new MemoryFile("zfoobar.prog.xml", xmlNoSelTexts));
+    const issues = await run(reg);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("mixed: parameter inside and outside BEGIN OF LINE, one issue", async () => {
+    const abap = `SELECTION-SCREEN BEGIN OF LINE.
+  PARAMETERS p_miss TYPE string.
+SELECTION-SCREEN END OF LINE.
+PARAMETERS p_miss2 TYPE string.`;
+    const reg = new Registry();
+    reg.addFile(new MemoryFile("zfoobar.prog.abap", abap));
+    reg.addFile(new MemoryFile("zfoobar.prog.xml", xmlNoSelTexts));
+    const issues = await run(reg);
+    expect(issues.length).to.equal(1);
+    expect(issues[0].getMessage()).to.include("P_MISS2");
+  });
+
 });


### PR DESCRIPTION
There are some cases where it's OK not to have a text assigned to a parameter:
- with the NO-DISPLAY addition
- When the parameter is inside a `BEGIN/END OF LINE` statement (the selection text is not rendered on screen)