### PR TITLE
Fix abaplint usage on Windows on a disk other than C:

### DIFF
--- a/packages/cli/src/file_operations.ts
+++ b/packages/cli/src/file_operations.ts
@@ -18,9 +18,12 @@ export class FileOperations {
     fs.rmSync(dir, {recursive: true});
   }
 
+  /** Normalize backslashes to forward slashes, keeping the drive letter so absolute
+   * paths/glob patterns resolve on the correct drive (the path may be on a different
+   * drive than the current working directory). */
   public static toUnixPath(path: string) {
     if (os.platform() === "win32") {
-      return path.replace(/[\\/]+/g, "/").replace(/^([a-zA-Z]+:|\.\/)/, "");
+      return path.replace(/[\\/]+/g, "/");
     } else {
       return path;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -113,14 +113,13 @@ async function loadDependencies(config: Config, compress: boolean | undefined, b
 
     if (d.url) {
       process.stderr.write("Clone: " + d.url + "\n");
-      let dir = fs.mkdtempSync(path.join(os.tmpdir(), "abaplint-"));
-      dir = FileOperations.toUnixPath(dir);
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "abaplint-"));
       let branch = "";
       if (d.branch) {
         branch = "-b " + d.branch + " ";
       }
       childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
-      const names = FileOperations.loadFileNames(dir + d.files);
+      const names = FileOperations.loadFileNames(FileOperations.toUnixPath(dir) + d.files);
       files = files.concat(await FileOperations.loadFiles(compress, names, bar));
       FileOperations.deleteFolderRecursive(dir);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -119,10 +119,7 @@ async function loadDependencies(config: Config, compress: boolean | undefined, b
         branch = "-b " + d.branch + " ";
       }
       childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
-      // normalize backslashes for glob, but keep the drive letter so the absolute
-      // pattern resolves on the correct drive (the temp dir may be on a different
-      // drive than the current working directory)
-      const names = FileOperations.loadFileNames(dir.replace(/\\/g, "/") + d.files);
+      const names = FileOperations.loadFileNames(FileOperations.toUnixPath(dir) + d.files);
       files = files.concat(await FileOperations.loadFiles(compress, names, bar));
       FileOperations.deleteFolderRecursive(dir);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -125,7 +125,10 @@ async function loadDependencies(config: Config, compress: boolean | undefined, b
           + " (cwd exists: " + fs.existsSync(dir) + ", process cwd: \"" + process.cwd() + "\")"
           + ": " + (e.message || e));
       }
-      const names = FileOperations.loadFileNames(FileOperations.toUnixPath(dir) + d.files);
+      // normalize backslashes for glob, but keep the drive letter so the absolute
+      // pattern resolves on the correct drive (the temp dir may be on a different
+      // drive than the current working directory)
+      const names = FileOperations.loadFileNames(dir.replace(/\\/g, "/") + d.files);
       files = files.concat(await FileOperations.loadFiles(compress, names, bar));
       FileOperations.deleteFolderRecursive(dir);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -118,13 +118,7 @@ async function loadDependencies(config: Config, compress: boolean | undefined, b
       if (d.branch) {
         branch = "-b " + d.branch + " ";
       }
-      try {
-        childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
-      } catch (e) {
-        throw new Error("Failed to clone " + d.url + " into cwd \"" + dir + "\""
-          + " (cwd exists: " + fs.existsSync(dir) + ", process cwd: \"" + process.cwd() + "\")"
-          + ": " + (e.message || e));
-      }
+      childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
       // normalize backslashes for glob, but keep the drive letter so the absolute
       // pattern resolves on the correct drive (the temp dir may be on a different
       // drive than the current working directory)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -118,7 +118,13 @@ async function loadDependencies(config: Config, compress: boolean | undefined, b
       if (d.branch) {
         branch = "-b " + d.branch + " ";
       }
-      childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
+      try {
+        childProcess.execSync("git clone --quiet --depth 1 " + branch + d.url + " .", {cwd: dir, stdio: "inherit"});
+      } catch (e) {
+        throw new Error("Failed to clone " + d.url + " into cwd \"" + dir + "\""
+          + " (cwd exists: " + fs.existsSync(dir) + ", process cwd: \"" + process.cwd() + "\")"
+          + ": " + (e.message || e));
+      }
       const names = FileOperations.loadFileNames(FileOperations.toUnixPath(dir) + d.files);
       files = files.concat(await FileOperations.loadFiles(compress, names, bar));
       FileOperations.deleteFolderRecursive(dir);

--- a/packages/cli/src/rename.ts
+++ b/packages/cli/src/rename.ts
@@ -72,8 +72,8 @@ export class Rename {
         continue;
       }
       for (const f of o.getFiles()) {
-        // yea, ffs
-        const n = outputFolder + f.getFilename().replace(myBase, "").replace("//?/C:", "");
+        // strip the long-path prefix (Windows) then the drive-qualified base
+        const n = outputFolder + f.getFilename().replace("//?/", "").replace(myBase, "");
         console.log("Write " + n);
         fs.mkdirSync(path.dirname(n), {recursive: true});
         fs.writeFileSync(n, f.getRaw());


### PR DESCRIPTION
Fixes #4036
Had three cascading issues:
- git clone would fail
- abaplint later failed to find the cloned dependencies (`Error: No files found, /Users/xxx/AppData/Local/Temp/abaplint-EYaTVJ/src/**/*.* undefined (generic_error) [E]`)
- `abaplint --rename` assumed we were always working on C:

Tested locally.
Disclaimer: I used Claude to fix this and don't master 100% of the code, feedback welcome