### PR TITLE
bugfix combi

### DIFF
--- a/packages/core/src/abap/2_statements/combi.ts
+++ b/packages/core/src/abap/2_statements/combi.ts
@@ -735,6 +735,10 @@ export abstract class Expression implements IStatementRunnable {
             const n = t.getNodes().slice(0, originalLength - consumed);
             n.push(re);
             t.setNodes(n);
+          } else {
+            // zero-consumption (empty) match: cache a pass-through marker so a
+            // cache hit reproduces this branch instead of silently dropping it.
+            cached.push({newTokenIndex: t.getTokenIndex()});
           }
           results.push(t);
         }
@@ -743,6 +747,11 @@ export abstract class Expression implements IStatementRunnable {
         }
       } else {
         for (const entry of cached) {
+          if (entry.children === undefined) {
+            const shifted = new Result(input.getTokens(), entry.newTokenIndex, input.getNodes().slice());
+            results.push(shifted);
+            continue;
+          }
           const re = new ExpressionNode(this);
           re.setChildren(entry.children.slice());
           const n = input.getNodes().slice();
@@ -1044,7 +1053,9 @@ class AlternativePriority implements IStatementRunnable {
   }
 }
 
-type MemoEntry = {children: readonly (ExpressionNode | TokenNode)[], newTokenIndex: number}[];
+// `children` is undefined for a zero-consumption (empty) match, which is
+// reproduced on a cache hit as a pass-through of the current input.
+type MemoEntry = {children?: readonly (ExpressionNode | TokenNode)[], newTokenIndex: number}[];
 
 export class Combi {
 // todo, change this class to be instantiated, constructor(runnable) ?


### PR DESCRIPTION
[combi.ts:744-753](vscode-webview://14b8cvcv76gt00i8q3d5sdsrjjf192jb8ijg1ropdblvh9fl8gev/packages/core/src/abap/2_statements/combi.ts#L744) — memoization drops zero-consumption (empty) matches on a cache hit (PLAUSIBLE).

On a cache miss, Expression.run pushes every result, including matches that consumed 0 tokens (the if (consumed > 0) block is skipped but results.push(t) still runs). Only consumed > 0 entries are stored in cached. On a cache hit, results are rebuilt solely from cached, so the empty-match (pass-through) branch is silently lost — and for an expression that only matched empty at that position, cached is [] and the hit yields nothing.

Three expressions can match empty: FindType (opt(...)), ValueBody (optPrio(...)), and LoopGroupByTarget (optPrio(...)). Failure scenario: if any empty-matching expression is evaluated twice at the same token index within one statement matcher (the exact reason the memo exists — expressions are re-tried at the same index during alternative/backtracking exploration), the second evaluation loses the "matched nothing here" branch. If the only valid full parse needed that branch, the statement fails to parse (order-dependent). I couldn't pin a triggering source line (FindType/ValueBody appear in linear seqs, so the test suite doesn't currently hit the same-index double-eval), which is why this is plausible rather than confirmed — but the divergence from the pre-PR behavior is concrete. Fix: also cache consumed === 0 results (e.g. an entry that reproduces the pass-through input).