### PR TITLE
fix stupid error from 4fc8f81d

### DIFF
--- a/packages/core/src/abap/2_statements/expressions/type_table_key.ts
+++ b/packages/core/src/abap/2_statements/expressions/type_table_key.ts
@@ -10,7 +10,7 @@ export class TypeTableKey extends Expression {
     const defaultKey = "DEFAULT KEY";
     const emptyKey = ver(Release.v740sp02, "EMPTY KEY", {also: AlsoIn.OpenABAP});
 
-    const components = plusPrio(seq(stopBefore1("WITH", "INITIAL", "VALUE", "WITHOUT"), stopBefore("READ", "-"), FieldSub));
+    const components = plusPrio(seq(stopBefore1("WITH", "INITIAL", "WITHOUT"), stopBefore("READ", "-"), FieldSub));
 
     const further = seq(alt("WITHOUT", "WITH"), "FURTHER SECONDARY KEYS");
 

--- a/packages/core/src/cds/expressions/cds_source.ts
+++ b/packages/core/src/cds/expressions/cds_source.ts
@@ -1,11 +1,11 @@
-import {CDSAs, CDSCondition, CDSFunction, CDSJoin, CDSName, CDSPrefixedName} from ".";
+import {CDSAs, CDSCondition, CDSFunction, CDSJoin, CDSName, CDSParametersSelect, CDSPrefixedName} from ".";
 import {altPrio, Expression, opt, optPrio, seq, star} from "../../abap/2_statements/combi";
 import {IStatementRunnable} from "../../abap/2_statements/statement_runnable";
 
 export class CDSSource extends Expression {
   public getRunnable(): IStatementRunnable {
     const staticFilter = seq("[", CDSCondition, "]");
-    const singleSource = seq(CDSPrefixedName, optPrio(staticFilter), opt(altPrio(CDSAs, CDSName)));
+    const singleSource = seq(CDSPrefixedName, optPrio(CDSParametersSelect), optPrio(staticFilter), opt(altPrio(CDSAs, CDSName)));
     const funcSingleSource = seq(CDSFunction, opt(altPrio(CDSAs, CDSName)));
     const parenSource = seq("(", altPrio(CDSSource, singleSource), star(CDSJoin), ")");
     return altPrio(parenSource, funcSingleSource, singleSource);

--- a/packages/core/test/abap/syntax/syntax.ts
+++ b/packages/core/test/abap/syntax/syntax.ts
@@ -7900,6 +7900,20 @@ data MT_TOKEN type TY_TOKEN_TT.`;
     expect(issues[0]?.getMessage()).to.equal(undefined);
   });
 
+  it("key component named VALUE should parse and resolve", () => {
+    const abap = `
+TYPES: BEGIN OF ty_content,
+         type  TYPE c LENGTH 12,
+         value TYPE c LENGTH 12,
+       END OF ty_content.
+TYPES ty_contents TYPE SORTED TABLE OF ty_content WITH UNIQUE KEY type value.
+DATA lt TYPE ty_contents.
+LOOP AT lt INTO DATA(ls).
+ENDLOOP.`;
+    const issues = runProgram(abap);
+    expect(issues[0]?.getMessage()).to.equal(undefined);
+  });
+
   it("CALL not found function module in cloud, should give error", () => {
     const abap = `CALL FUNCTION 'NOT_RELEASED'.`;
     const issues = runProgram(abap, [], Version.Cloud, undefined, LanguageVersion.Cloud);


### PR DESCRIPTION
stopBefore1 included "VALUE" to guard against VALUE #( ) constructors, but FieldSub would reject those naturally. Any field literally named value (e.g. WITH UNIQUE KEY type value) was silently dropped, causing unknown_types/check_syntax false positives in abapGit and abapTimeMachine.