### PR TITLE
feat(CDS): wrap define table entity fields in CDSTableField node

### DIFF
--- a/packages/core/src/cds/expressions/cds_define_table_entity.ts
+++ b/packages/core/src/cds/expressions/cds_define_table_entity.ts
@@ -1,14 +1,15 @@
-import {CDSAnnotation, CDSAssociation, CDSComposition, CDSElement, CDSJoin, CDSName,
-  CDSSource, CDSType, CDSWhere, CDSWithParameters} from ".";
-import {Expression, str, seq, star, opt, optPrio, plus, alt, altPrio} from "../../abap/2_statements/combi";
+import {CDSAnnotation, CDSElement, CDSJoin, CDSName,
+  CDSSource, CDSTableField, CDSWhere, CDSWithParameters,
+  CDSAssociation, CDSComposition} from ".";
+import {Expression, str, seq, star, opt, optPrio, plus, altPrio} from "../../abap/2_statements/combi";
 import {IStatementRunnable} from "../../abap/2_statements/statement_runnable";
 
 export class CDSDefineTableEntity extends Expression {
   public getRunnable(): IStatementRunnable {
-    const nullability = optPrio(alt("NOT NULL", "NULL"));
-    const field = seq(star(CDSAnnotation), optPrio(str("KEY")), CDSName, ":", CDSType, nullability, ";");
-    const assocOrComp = seq(star(CDSAnnotation), CDSName, ":", alt(CDSComposition, CDSAssociation), ";");
-    const inlineBody = plus(alt(field, assocOrComp));
+    // Inline `{ ... }` body: one or more table-field entries. Each entry is
+    // wrapped in a CDSTableField node so downstream tooling can pair each
+    // field name with its own annotations.
+    const inlineBody = plus(CDSTableField);
 
     const elementList = seq(CDSElement, star(seq(",", CDSElement)), opt(","));
     const elements = seq(str("{"), altPrio("*", elementList), str("}"));

--- a/packages/core/src/cds/expressions/cds_table_field.ts
+++ b/packages/core/src/cds/expressions/cds_table_field.ts
@@ -1,0 +1,16 @@
+import {CDSAnnotation, CDSAssociation, CDSComposition, CDSName, CDSType} from ".";
+import {Expression, str, seq, star, optPrio, alt} from "../../abap/2_statements/combi";
+import {IStatementRunnable} from "../../abap/2_statements/statement_runnable";
+
+// A single field or association/composition inside a `define table entity { ... }`
+// inline body. Wraps annotations + name + type together so tooling can iterate
+// per-field with associated field-level annotations (matches the CDSElement
+// shape used for select-list elements).
+export class CDSTableField extends Expression {
+  public getRunnable(): IStatementRunnable {
+    const nullability = optPrio(alt("NOT NULL", "NULL"));
+    const field = seq(optPrio(str("KEY")), CDSName, ":", CDSType, nullability);
+    const assocOrComp = seq(CDSName, ":", alt(CDSComposition, CDSAssociation));
+    return seq(star(CDSAnnotation), alt(field, assocOrComp), ";");
+  }
+}

--- a/packages/core/src/cds/expressions/index.ts
+++ b/packages/core/src/cds/expressions/index.ts
@@ -38,6 +38,7 @@ export * from "./cds_relation";
 export * from "./cds_select";
 export * from "./cds_source";
 export * from "./cds_string";
+export * from "./cds_table_field";
 export * from "./cds_type";
 export * from "./cds_where";
 export * from "./cds_with_parameters";

--- a/packages/core/test/cds/cds_parser.ts
+++ b/packages/core/test/cds/cds_parser.ts
@@ -3526,4 +3526,56 @@ association to TARGET as _t on _t.id = BASE.id
     expect(new CDSParser().parse(new MemoryFile("v.ddls.asddls", cds))).to.be.instanceof(ExpressionNode);
   });
 
+  it("define table entity — field annotations sit under CDSTableField", () => {
+    const cds = `@EndUserText.label: 'head'
+define table entity T {
+  key id : abap.int4 not null;
+  @EndUserText.label: 'field1 label'
+  @Semantics.text: true
+  field1 : abap.char(30);
+  @EndUserText.label: 'field2 label'
+  field2 : abap.char(5);
+}`;
+    const file = new MemoryFile("t.ddls.asddls", cds);
+    const parsed = new CDSParser().parse(file);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+    // Find all CDSTableField nodes — each should carry its own annotations.
+    const tableFields = findAll(parsed!, "CDSTableField");
+    expect(tableFields.length).to.equal(3);
+    // The first field (key id) has 0 annotations, the second/third each have annotations.
+    const withAnnos = tableFields.filter(tf => findAll(tf, "CDSAnnotation").length > 0);
+    expect(withAnnos.length).to.equal(2);
+    // Head annotation stays direct child of the root, not wrapped in CDSTableField.
+    const rootAnnos = parsed!.getChildren().filter(c => c.get().constructor.name === "CDSAnnotation");
+    expect(rootAnnos.length).to.equal(1);
+  });
+
+  it("define table entity with association/composition wrapped in CDSTableField", () => {
+    const cds = `define table entity T {
+  key id : abap.int4 not null;
+  @Semantics.text: true
+  _rel : association to O on _rel.id = T.id;
+}`;
+    const file = new MemoryFile("t.ddls.asddls", cds);
+    const parsed = new CDSParser().parse(file);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+    const tableFields = findAll(parsed!, "CDSTableField");
+    expect(tableFields.length).to.equal(2);
+    // The assoc should carry the annotation.
+    const withAnnos = tableFields.filter(tf => findAll(tf, "CDSAnnotation").length > 0);
+    expect(withAnnos.length).to.equal(1);
+  });
+
 });
+
+// Recursively find all nodes of a given class name under `n`.
+function findAll(n: any, className: string): any[] {
+  const out: any[] = [];
+  function walk(x: any): void {
+    const k = x.get?.()?.constructor?.name;
+    if (k === className) { out.push(x); }
+    for (const c of x.getChildren?.() ?? []) { walk(c); }
+  }
+  walk(n);
+  return out;
+}


### PR DESCRIPTION
Each entry in a `define table entity { ... }` body (regular field, KEY field, association, composition) is now wrapped in its own CDSTableField expression node, bundling per-field annotations with the field name and type so tooling can iterate fields and access their annotations directly.