### PR TITLE
CDS Parser: Support Quoted Strings in CDS

### DIFF
--- a/packages/core/src/cds/expressions/cds_string.ts
+++ b/packages/core/src/cds/expressions/cds_string.ts
@@ -3,7 +3,7 @@ import {IStatementRunnable} from "../../abap/2_statements/statement_runnable";
 
 export class CDSString extends Expression {
   public getRunnable(): IStatementRunnable {
-    const reg = regex(/^(?:'(?:[^'\\]|''|\\'|\\\\|\\(?!'))*'|"(?:[^"\\]|""|\\"|\\\\|\\(?!"))*")$/);
+    const reg = regex(/^'(?:[^'\\]|''|\\'|\\\\|\\(?!'))*'$/);
     const abapTypeName = regex(/^(?:int[1-9]|int8|sstring|sstr|char|numc|dats|datn|tims|timn|utcl|utclong|fltp|decfloat\d+|dec|string|rawstring|rstr|raw|xstring|clnt|lang|unit|cuky|curr|quan|geom_ewkb|d34n|d16n|d34d|d16d|d34s|d16s|d34r|d16r|d|t|p|n|c|x|f)$/i);
     const abap = seq("abap", ".", abapTypeName, optPrio(seq("(", regex(/^\d+$/), ")")), reg);
     return altPrio(abap, reg);

--- a/packages/core/test/cds/cds_parser.ts
+++ b/packages/core/test/cds/cds_parser.ts
@@ -3579,3 +3579,59 @@ function findAll(n: any, className: string): any[] {
   walk(n);
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Quoted identifier support in CDSName
+// ---------------------------------------------------------------------------
+describe("CDS Parser — quoted identifiers", () => {
+
+  function parse(source: string) {
+    const file = new MemoryFile("v.ddls.acds", source);
+    return new CDSParser().parse(file);
+  }
+
+  it("FROM-clause alias with standard name quoted: parses successfully", () => {
+    const parsed = parse(`define view v as select from t as "MyAlias" { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+  it("FROM-clause alias with = prefix: parses successfully", () => {
+    const parsed = parse(`define view v as select from t as "=A0" { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+  it("JOIN alias with = prefix: parses successfully", () => {
+    const parsed = parse(`define view v as select from t inner join u as "=A1" on t.id = u.id { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+  it("column alias with = prefix: parses successfully", () => {
+    const parsed = parse(`define view v as select from t { key t.id as "=MYKEY" }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+  it("FROM-clause alias '\"=A0\"' token value preserved in CDSAs → CDSName", () => {
+    const parsed = parse(`define view v as select from t as "=A0" { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+    // Find CDSSource's CDSAs child and read the alias token
+    const sources = findAll(parsed, "CDSSource");
+    expect(sources.length).to.equal(1);
+    const asNodes = findAll(sources[0], "CDSAs");
+    expect(asNodes.length).to.equal(1);
+    const nameNodes = findAll(asNodes[0], "CDSName");
+    expect(nameNodes.length).to.be.greaterThan(0);
+    const tok = nameNodes[0].getFirstToken().getStr();
+    expect(tok).to.equal('"=A0"');
+  });
+
+  it("quoted identifier with special chars (hyphen) parses", () => {
+    const parsed = parse(`define view v as select from t as "my-alias" { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+  it("view name itself can be quoted", () => {
+    const parsed = parse(`define view "MyView" as select from t { key t.id }`);
+    expect(parsed).to.be.instanceof(ExpressionNode);
+  });
+
+});


### PR DESCRIPTION
They are removed when saving, but CDS officially supports and parses them and can activate them.