### PR TITLE
Fix main file lookup for URL-encoded namespaces

### DIFF
--- a/packages/core/src/objects/_abap_object.ts
+++ b/packages/core/src/objects/_abap_object.ts
@@ -80,10 +80,10 @@ export abstract class ABAPObject extends AbstractObject {
   }
 
   public getMainABAPFile(): ABAPFile | undefined {
-    // todo, uris, https://github.com/abaplint/abaplint/issues/673
     const search = this.getName().replace(/\//g, "#").toLowerCase() + "." + this.getType().toLowerCase() + ".abap";
+    const encodedSearch = search.replace(/#/g, "%23");
     for (const file of this.getABAPFiles()) {
-      if (file.getFilename().endsWith(search)) {
+      if (file.getFilename().endsWith(search) || file.getFilename().endsWith(encodedSearch)) {
         return file;
       }
     }

--- a/packages/core/test/registry.ts
+++ b/packages/core/test/registry.ts
@@ -88,6 +88,20 @@ describe("Registry", () => {
     expect(reg.getObject("CLAS", "/namesp/cl_foobar")).to.not.equal(undefined);
   });
 
+  it("URL encoded namespaced class resolves main file before test include", async () => {
+    const test = new MemoryFile(
+      "file:///src/%23namesp%23cl_foobar.clas.testclasses.abap",
+      "CLASS ltc_test DEFINITION FOR TESTING. ENDCLASS.");
+    const main = new MemoryFile(
+      "file:///src/%23namesp%23cl_foobar.clas.abap",
+      "CLASS /namesp/cl_foobar DEFINITION. ENDCLASS.");
+    const reg = new Registry().addFiles([test, main]);
+    await reg.parseAsync();
+
+    const object = reg.getObject("CLAS", "/namesp/cl_foobar") as ABAPObject;
+    expect(object.getMainABAPFile()?.getFilename()).to.equal(main.getFilename());
+  });
+
   it("filename with namespace, with dash", async () => {
     const reg = new Registry().addFile(new MemoryFile("/src/%23name-sp%23cl_foobar.clas.abap", "parser error"));
     expect(reg.getObjectCount().normal).to.equal(1);


### PR DESCRIPTION
## Summary

- Recognize URL-encoded namespace separators (`%23`) when resolving an ABAP object's main file.
- Prevent a class test include from being selected as the main class when file enumeration returns it first.
- Add a regression test where a namespaced test-class include precedes the main class file.

## Problem

VS Code represents namespaced filenames such as:

`#namesp#cl_foobar.clas.abap`

as URI-encoded paths:

`%23namesp%23cl_foobar.clas.abap`

`getMainABAPFile()` only searched for the `#namesp#` form. When that search failed, it returned the first ABAP file as a fallback. Since filesystem enumeration order is not deterministic, this could select `.clas.testclasses.abap` and resolve the global class as its local test class.

Related issue: https://github.com/abaplint/vscode-abaplint/issues/201