### PR TITLE
fix: urls to external sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "web.playground": "cd web/playground && npm install && npm test && npm run build && cd ../../",
         "web.rules": "cd web/rules && npm install && npm test && cd ../../",
         "web.syntax": "cd web/syntax/ && node index.mjs && cd ../../",
+        "check:urls": "node scripts/check-urls.mjs",
         "watch:core": "cd packages/core && npm run watch",
         "link-local": "npm run link:core && npm run link:monaco && npm run link:core-into-cli && npm run link:cli && npm run link:core-into-monaco && npm run link:core-into-playground && npm run link:monaco-into-playground",
         "link:core": "cd packages/core && npm link",

--- a/packages/core/src/abap/2_statements/expressions/compare.ts
+++ b/packages/core/src/abap/2_statements/expressions/compare.ts
@@ -25,7 +25,7 @@ export class Compare extends Expression {
 
     const between = seq(optPrio("NOT"), "BETWEEN", Source, "AND", Source);
 
-// https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abennews-740_sp08-expressions.htm
+// https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abennews-740_sp08-expressions.html
 // but also seems to work in v740sp05, blah
     const predicate = ver(Release.v740sp08, MethodCallChain, {also: AlsoIn.OpenABAP});
 

--- a/packages/core/src/abap/2_statements/expressions/string_template_formatting.ts
+++ b/packages/core/src/abap/2_statements/expressions/string_template_formatting.ts
@@ -7,7 +7,7 @@ import {Dynamic} from "./dynamic";
 export class StringTemplateFormatting extends Expression {
   public getRunnable(): IStatementRunnable {
 
-    // https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abapcompute_string_format_options.htm
+    // https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapcompute_string_format_options.html
     const alphaOptions = altPrio("OUT", "RAW", "IN", Source);
 
     const alignOptions = altPrio("LEFT", "RIGHT", "CENTER", Source, Dynamic);

--- a/packages/core/src/abap/5_syntax/_builtin.ts
+++ b/packages/core/src/abap/5_syntax/_builtin.ts
@@ -1340,7 +1340,7 @@ export class BuiltIn {
     const id2 = new TokenIdentifier(new Position(this.row++, 1), "syst");
     const syst = new TypedIdentifier(id2, BuiltIn.filename, type, [IdentifierMeta.ReadOnly, IdentifierMeta.BuiltIn]);
 
-    // https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abennews-610-system.htm
+    // https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abennews-610-system.html
     const id3 = new TokenIdentifier(new Position(this.row++, 1), "sy-repid");
     const syrepid = new TypedIdentifier(id3, BuiltIn.filename, new CharacterType(40, {qualifiedName: "sy-repid"}), [IdentifierMeta.ReadOnly, IdentifierMeta.BuiltIn]);
     const id4 = new TokenIdentifier(new Position(this.row++, 1), "syst-repid");

--- a/packages/core/src/rules/7bit_ascii.ts
+++ b/packages/core/src/rules/7bit_ascii.ts
@@ -18,7 +18,7 @@ export class SevenBitAscii implements IRule {
       shortDescription: `Only allow characters from the 7bit ASCII set.`,
       extendedInformation: `https://docs.abapopenchecks.org/checks/05/
 
-https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abencharacter_set_guidl.htm
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abencharacter_set_guidl.html
 
 Checkes files with extensions ".abap" and ".asddls"`,
       tags: [RuleTag.SingleFile],

--- a/packages/core/src/rules/avoid_use.ts
+++ b/packages/core/src/rules/avoid_use.ts
@@ -42,7 +42,7 @@ export class AvoidUse extends ABAPRule {
       shortDescription: `Detects usage of certain statements.`,
       extendedInformation: `DEFAULT KEY: https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#avoid-default-key
 
-Macros: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abenmacros_guidl.htm
+Macros: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenmacros_guidl.html
 
 STATICS: use CLASS-DATA instead
 

--- a/packages/core/src/rules/cds_comment_style.ts
+++ b/packages/core/src/rules/cds_comment_style.ts
@@ -22,7 +22,7 @@ export class CDSCommentStyle implements IRule {
 
 Comments starting with "--" are considered obsolete
 
-https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abencds_general_syntax_rules.htm`,
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abencds_general_syntax_rules.html`,
       tags: [RuleTag.SingleFile],
       badExample: "-- this is a comment",
       goodExample: "// this is a comment",

--- a/packages/core/src/rules/chain_mainly_declarations.ts
+++ b/packages/core/src/rules/chain_mainly_declarations.ts
@@ -46,7 +46,7 @@ export class ChainMainlyDeclarations extends ABAPRule {
       extendedInformation: `
 https://docs.abapopenchecks.org/checks/23/
 
-https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abenchained_statements_guidl.htm
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenchained_statements_guidl.html
 `,
       tags: [RuleTag.SingleFile, RuleTag.Quickfix],
       badExample: `CALL METHOD: bar.`,

--- a/packages/core/src/rules/clear_exporting_parameters.ts
+++ b/packages/core/src/rules/clear_exporting_parameters.ts
@@ -36,7 +36,7 @@ before reading it, so a leftover value is not accidentally used.
 
 https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#clear-or-overwrite-exporting-reference-parameters
 
-https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenref_transf_output_param_guidl.htm
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenref_transf_output_param_guidl.html
 
 Note: EXPORTING parameters passed by VALUE are always initialized and are therefore not reported.
 Reading and writing the parameter in the same statement (e.g. "ev_result = ev_result + 1") is reported,

--- a/packages/core/src/rules/constructor_visibility_public.ts
+++ b/packages/core/src/rules/constructor_visibility_public.ts
@@ -22,7 +22,7 @@ export class ConstructorVisibilityPublic implements IRule {
 This only applies to global classes.
 
 https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#if-your-global-class-is-create-private-leave-the-constructor-public
-https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abeninstance_constructor_guidl.htm`,
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abeninstance_constructor_guidl.html`,
       tags: [RuleTag.Styleguide, RuleTag.SingleFile],
       badExample: `CLASS zcl_foo DEFINITION PUBLIC CREATE PRIVATE.
   PRIVATE SECTION.

--- a/packages/core/src/rules/exit_or_check.ts
+++ b/packages/core/src/rules/exit_or_check.ts
@@ -22,8 +22,8 @@ export class ExitOrCheck extends ABAPRule {
       title: "Find EXIT or CHECK outside loops",
       shortDescription: `Detects usages of EXIT or CHECK statements outside of loops.
 Use RETURN to leave procesing blocks instead.`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abenleave_processing_blocks.htm
-https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abapcheck_processing_blocks.htm
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenleave_processing_blocks.html
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapcheck_processing_blocks.html
 https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#check-vs-return`,
       tags: [RuleTag.Styleguide, RuleTag.SingleFile, RuleTag.Quickfix],
       badExample: `CHECK is_valid = abap_true.

--- a/packages/core/src/rules/expand_macros.ts
+++ b/packages/core/src/rules/expand_macros.ts
@@ -20,7 +20,7 @@ export class ExpandMacros extends ABAPRule {
       key: "expand_macros",
       title: "Expand Macros",
       shortDescription: `Allows expanding macro calls with quick fixes`,
-      extendedInformation: `Macros: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abenmacros_guidl.htm
+      extendedInformation: `Macros: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenmacros_guidl.html
 
 Note that macros/DEFINE cannot be used in the ABAP Cloud programming model`,
       badExample: `DEFINE _hello.

--- a/packages/core/src/rules/fm_global_parameters_obsolete.ts
+++ b/packages/core/src/rules/fm_global_parameters_obsolete.ts
@@ -17,7 +17,7 @@ export class FMGlobalParametersObsolete implements IRule {
       key: "fm_global_parameters_obsolete",
       title: "FM Global Parameters Obsolete",
       shortDescription: `Check for function modules with global parameters`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abenglobal_parameters_obsolete.htm`,
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenglobal_parameters_obsolete.html`,
       tags: [],
     };
   }

--- a/packages/core/src/rules/form_tables_obsolete.ts
+++ b/packages/core/src/rules/form_tables_obsolete.ts
@@ -19,7 +19,7 @@ export class FormTablesObsolete extends ABAPRule {
       key: "form_tables_obsolete",
       title: "TABLES parameters are obsolete",
       shortDescription: `Checks for TABLES parameters in forms.`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abapform_tables.htm`,
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapform_tables.html`,
       tags: [RuleTag.SingleFile],
       badExample: `FORM update_items TABLES items.
 ENDFORM.`,

--- a/packages/core/src/rules/implicit_start_of_selection.ts
+++ b/packages/core/src/rules/implicit_start_of_selection.ts
@@ -23,7 +23,7 @@ export class ImplicitStartOfSelection extends ABAPRule {
       shortDescription: `Add explicit selection screen event handling`,
       extendedInformation: `Only runs for executable programs
 
-https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapstart-of-selection.htm`,
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapstart-of-selection.html`,
       tags: [RuleTag.SingleFile],
       badExample: `REPORT zfoo.
 WRITE 'hello'.`,

--- a/packages/core/src/rules/method_overwrites_builtin.ts
+++ b/packages/core/src/rules/method_overwrites_builtin.ts
@@ -18,7 +18,7 @@ export class MethodOverwritesBuiltIn extends ABAPRule {
       key: "method_overwrites_builtin",
       title: "Method name overwrites builtin function",
       shortDescription: `Checks Method names that overwrite builtin SAP functions`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abenbuilt_in_functions_overview.htm
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abenbuilt_in_functions_overview.html
 
 https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#avoid-obscuring-built-in-functions
 

--- a/packages/core/src/rules/mix_returning.ts
+++ b/packages/core/src/rules/mix_returning.ts
@@ -21,7 +21,7 @@ export class MixReturning extends ABAPRule {
       shortDescription: `Checks that methods don't have a mixture of returning and exporting/changing parameters`,
       extendedInformation: `https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#use-either-returning-or-exporting-or-changing-but-not-a-combination
 
-This syntax is not allowed on versions earlier than 740sp02, https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abennews-740-abap_objects.htm#!ABAP_MODIFICATION_1@1@`,
+This syntax is not allowed on versions earlier than 740sp02, https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abennews-740-abap_objects.html#!ABAP_MODIFICATION_1@1@`,
       tags: [RuleTag.Styleguide, RuleTag.SingleFile, RuleTag.Syntax],
       badExample: `CLASS lcl DEFINITION.
   PUBLIC SECTION.

--- a/packages/core/src/rules/no_macros.ts
+++ b/packages/core/src/rules/no_macros.ts
@@ -19,7 +19,7 @@ export class NoMacros extends ABAPRule {
       shortDescription: `Checks that macros are not used`,
       extendedInformation: `Macros reduce readability and are difficult to debug, use methods or form routines instead.
 
-https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenmacros_guidl.htm`,
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenmacros_guidl.html`,
       tags: [RuleTag.SingleFile],
       badExample: `DEFINE _macro.
   WRITE 'hello'.

--- a/packages/core/src/rules/obsolete_statement.ts
+++ b/packages/core/src/rules/obsolete_statement.ts
@@ -95,44 +95,44 @@ https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#prefer-func
 
 https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#avoid-obsolete-language-elements
 
-SET EXTENDED CHECK: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapset_extended_check.htm
+SET EXTENDED CHECK: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapset_extended_check.html
 
-IS REQUESTED: https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abenlogexp_requested.htm
+IS REQUESTED: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenlogexp_requested.html
 
-WITH HEADER LINE: https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abapdata_header_line.htm
+WITH HEADER LINE: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapdata_header_line.html
 
-FIELD-SYMBOLS STRUCTURE: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapfield-symbols_obsolete_typing.htm
+FIELD-SYMBOLS STRUCTURE: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapfield-symbols_obsolete_typing.html
 
-TYPE-POOLS: from 702, https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abennews-71-program_load.htm
+TYPE-POOLS: from 702, https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abennews-71-program_load.html
 
-LOAD addition: from 702, https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abennews-71-program_load.htm
+LOAD addition: from 702, https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abennews-71-program_load.html
 
-COMMUICATION: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapcommunication.htm
+COMMUICATION: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapcommunication.html
 
-OCCURS: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapdata_occurs.htm
+OCCURS: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapdata_occurs.html
 
-PARAMETER: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abapparameter.htm
+PARAMETER: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapparameter.html
 
-RANGES: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapranges.htm
+RANGES: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapranges.html
 
-PACK: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abappack.htm
+PACK: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abappack.html
 
-MOVE: https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abapmove_obs.htm
+MOVE: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapmove_obs.html
 
-SELECT without INTO: https://help.sap.com/doc/abapdocu_731_index_htm/7.31/en-US/abapselect_obsolete.htm
+SELECT without INTO: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapselect_obsolete.html
 SELECT COUNT(*) is considered okay
 
-FREE MEMORY: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abapfree_mem_id_obsolete.htm
+FREE MEMORY: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abapfree_mem_id_obsolete.html
 
-SORT BY FS: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapsort_itab_obsolete.htm
+SORT BY FS: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapsort_itab_obsolete.html
 
-CALL TRANSFORMATION OBJECTS: https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abapcall_transformation_objects.htm
+CALL TRANSFORMATION OBJECTS: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapcall_transformation_objects.html
 
-POSIX REGEX: https://help.sap.com/doc/abapdocu_755_index_htm/7.55/en-US/index.htm
+POSIX REGEX: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENREGEX_MIGRATING_POSIX.html
 
 OCCURENCES: check for OCCURENCES vs OCCURRENCES
 
-CLIENT SPECIFIED, from 754: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/index.htm?file=abapselect_client_obsolete.htm`,
+CLIENT SPECIFIED, from 754: https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapselect_client_obsolete.html`,
       badExample: `REFRESH itab.
 
 COMPUTE foo = 2 + 2.

--- a/packages/core/src/rules/pragma_style.ts
+++ b/packages/core/src/rules/pragma_style.ts
@@ -18,7 +18,7 @@ export class PragmaStyle extends ABAPRule {
       title: "Pragma Style",
       shortDescription: `Check pragmas placement and case`,
       tags: [RuleTag.SingleFile],
-      extendedInformation: `https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/abenpragma.htm`,
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENPRAGMA.html`,
       badExample: `DATA field ##NO_TEXT TYPE i.`,
       goodExample: `DATA field TYPE i ##NO_TEXT.`,
     };

--- a/packages/core/src/rules/rfc_error_handling.ts
+++ b/packages/core/src/rules/rfc_error_handling.ts
@@ -18,7 +18,7 @@ export class RFCErrorHandling extends ABAPRule {
       title: "RFC error handling",
       tags: [RuleTag.SingleFile],
       shortDescription: `Checks that exceptions 'system_failure' and 'communication_failure' are handled in RFC calls`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abenrfc_exception.htm`,
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenrfc_exception.html`,
       badExample: `CALL FUNCTION 'ZRFC'
   DESTINATION lv_rfc.`,
       goodExample: `CALL FUNCTION 'ZRFC'

--- a/packages/core/src/rules/strict_sql.ts
+++ b/packages/core/src/rules/strict_sql.ts
@@ -20,9 +20,9 @@ export class StrictSQL extends ABAPRule {
       key: "strict_sql",
       title: "Strict SQL",
       shortDescription: `Strict SQL`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abapinto_clause.htm
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapinto_clause.html
 
-https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abenopensql_strict_mode_750.htm
+https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENABAP_SQL_STRICT_MODES.html
 
 Also see separate rule sql_escape_host_variables
 

--- a/packages/core/src/rules/sy_modification.ts
+++ b/packages/core/src/rules/sy_modification.ts
@@ -18,7 +18,7 @@ export class SyModification extends ABAPRule {
       key: "sy_modification",
       title: "Modification of SY fields",
       shortDescription: `Finds modification of sy fields`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abensystem_fields.htm
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abensystem_fields.html
 
 Changes to SY-TVAR* fields are not reported
 

--- a/packages/core/src/rules/tables_declared_locally.ts
+++ b/packages/core/src/rules/tables_declared_locally.ts
@@ -17,7 +17,7 @@ export class TablesDeclaredLocally extends ABAPRule {
       key: "tables_declared_locally",
       title: "Check for locally declared TABLES",
       shortDescription: `TABLES are always global, so declare them globally`,
-      extendedInformation: `https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-us/abaptables.htm`,
+      extendedInformation: `https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-us/abaptables.html`,
       tags: [RuleTag.SingleFile],
       badExample: `FORM foo.
   TABLES t100.

--- a/scripts/check-urls.mjs
+++ b/scripts/check-urls.mjs
@@ -1,0 +1,272 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outputFile = path.join(repoRoot, "url-check-errors.md");
+
+const SKIP_DIRS = new Set(["node_modules", ".git", "build", "dist", ".next"]);
+const SKIP_FILES = new Set(["url-check-errors.md"]);
+const TEXT_EXTENSIONS = new Set([
+  ".ts", ".js", ".mjs", ".json", ".md", ".adoc", ".html", ".xml", ".yml", ".yaml",
+  ".css", ".scss", ".txt", ".svg", ".abap", ".cls", ".intf",
+]);
+
+const URL_REGEX = /https?:\/\/[^\s\)\]\"\'\`<>\\]+/gi;
+
+function cleanUrl(raw) {
+  let url = raw.replace(/[.,;:!?]+$/, "");
+  url = url.replace(/\\+$/, "");
+  url = url.replace(/&quot;.*$/i, "");
+  url = url.replace(/&lt;.*$/i, "");
+  url = url.replace(/%22.*$/, "");
+  url = url.replace(/&amp;.*$/i, "");
+  url = url.replace(/&quot;?$/i, "");
+  while (url.endsWith(")") || url.endsWith("]") || url.endsWith("'") || url.endsWith('"')) {
+    url = url.slice(0, -1);
+  }
+  return url;
+}
+
+const SKIP_URL_PATTERNS = [
+  /^https?:\/\/www\.w3\.org\//,
+  /^https?:\/\/www\.sap\.com\/abapxml/,
+  /^https?:\/\/sodipodi\.sourceforge\.net\//,
+  /^https?:\/\/www\.inkscape\.org\/namespaces\//,
+  /^https?:\/\/www\.openswatchbook\.org\//,
+  /^https?:\/\/purl\.org\//,
+  /^https?:\/\/xmlns\./,
+  /^https?:\/\/schemas\.microsoft\.com\//,
+  /^https?:\/\/schemas\.openxmlformats\.org\//,
+];
+
+function shouldSkipUrl(url) {
+  return SKIP_URL_PATTERNS.some((re) => re.test(url));
+}
+
+const GET_ONLY_HOSTS = [
+  "marketplace.visualstudio.com",
+  "www.npmjs.com",
+  "npmjs.com",
+];
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, files);
+    } else if (entry.isFile()) {
+      if (SKIP_FILES.has(entry.name)) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (TEXT_EXTENSIONS.has(ext) || entry.name.startsWith(".")) {
+        files.push(full);
+      }
+    }
+  }
+  return files;
+}
+
+function extractUrls(content) {
+  const matches = content.match(URL_REGEX) || [];
+  return matches.map(cleanUrl).filter((u) => u.length > 10);
+}
+
+function getSapHelpTopic(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "help.sap.com" || !parsed.pathname.includes("/doc/")) {
+      return "";
+    }
+    const fileParam = parsed.searchParams.get("file");
+    if (fileParam) {
+      return path.basename(fileParam).replace(/\.(htm|html)$/i, "");
+    }
+    return path.basename(parsed.pathname).replace(/\.(htm|html)$/i, "");
+  } catch {
+    return "";
+  }
+}
+
+function isSapHelpSoft404(url, body) {
+  if (body.length < 3500) {
+    return true;
+  }
+
+  const title = (body.match(/<title[^>]*>([^<]+)/i) || [])[1]?.trim() || "";
+  if (/ABAP Keyword Documentation/i.test(title) && title.length > 25) {
+    return false;
+  }
+
+  const topic = getSapHelpTopic(url);
+  if (!topic || topic.toLowerCase() === "index") {
+    return body.length < 5000;
+  }
+
+  const variants = new Set([topic.toUpperCase()]);
+  if (topic.startsWith("abap")) {
+    variants.add(topic.slice(4).toUpperCase());
+  }
+  if (topic.startsWith("aben")) {
+    variants.add(topic.slice(4).toUpperCase());
+  }
+
+  const upperBody = body.toUpperCase();
+  return ![...variants].some((v) => upperBody.includes(v));
+}
+
+async function fetchUrl(url, method, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method,
+      signal: controller.signal,
+      redirect: "follow",
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+    clearTimeout(timer);
+    return response;
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+async function checkUrl(url, timeoutMs = 20000) {
+  const hostname = (() => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return "";
+    }
+  })();
+  const sapHelpDoc = hostname === "help.sap.com" && getSapHelpTopic(url);
+  const preferGet = sapHelpDoc || GET_ONLY_HOSTS.some((h) => hostname === h || hostname.endsWith("." + h));
+  const methods = preferGet ? ["GET"] : ["HEAD", "GET"];
+
+  for (const method of methods) {
+    try {
+      const response = await fetchUrl(url, method, timeoutMs);
+      if (response.ok || (response.status >= 300 && response.status < 400)) {
+        if (sapHelpDoc && method === "GET") {
+          const body = await response.text();
+          if (isSapHelpSoft404(url, body)) {
+            return { ok: false, status: response.status, error: "SAP Help soft 404 (page not found)" };
+          }
+        }
+        return { ok: true, status: response.status };
+      }
+      if (method === "HEAD" && [403, 405, 501].includes(response.status)) {
+        continue;
+      }
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` };
+    } catch (err) {
+      if (method === "GET") {
+        return { ok: false, error: err.name === "AbortError" ? "Timeout" : String(err.message || err) };
+      }
+    }
+  }
+  return { ok: false, error: "Request failed" };
+}
+
+async function runPool(items, concurrency, fn) {
+  const results = new Array(items.length);
+  let index = 0;
+  async function worker() {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return results;
+}
+
+console.log("Scanning files...");
+const files = walk(repoRoot);
+const urlMap = new Map();
+
+for (const file of files) {
+  let content;
+  try {
+    content = fs.readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  const urls = extractUrls(content);
+  const rel = path.relative(repoRoot, file).replace(/\\/g, "/");
+  for (const url of urls) {
+    if (shouldSkipUrl(url)) continue;
+    if (!urlMap.has(url)) urlMap.set(url, new Set());
+    urlMap.get(url).add(rel);
+  }
+}
+
+const skippedNamespaceCount = [...new Set(
+  files.flatMap((file) => {
+    try {
+      return extractUrls(fs.readFileSync(file, "utf8")).filter(shouldSkipUrl);
+    } catch {
+      return [];
+    }
+  }),
+)].length;
+
+const uniqueUrls = [...urlMap.keys()].sort();
+console.log(`Found ${uniqueUrls.length} unique URLs in ${files.length} files`);
+
+console.log("Checking URLs (concurrency 10)...");
+const checkResults = await runPool(uniqueUrls, 10, async (url) => {
+  const result = await checkUrl(url);
+  process.stdout.write(result.ok ? "." : "X");
+  return { url, ...result };
+});
+console.log("\nDone checking.");
+
+const errors = checkResults.filter((r) => {
+  if (r.ok) return false;
+  try {
+    const host = new URL(r.url).hostname;
+    if ((host === "www.npmjs.com" || host === "npmjs.com") && r.status === 403) {
+      return false;
+    }
+  } catch {
+    // keep error
+  }
+  return true;
+});
+errors.sort((a, b) => a.url.localeCompare(b.url));
+
+const lines = [
+  "# URL Check Errors",
+  "",
+  `Generated: ${new Date().toISOString()}`,
+  "",
+  `Scanned ${files.length} files, found ${uniqueUrls.length} unique URLs (${skippedNamespaceCount} XML/SVG namespace URIs skipped).`,
+  `Working: ${checkResults.length - errors.length}, Errors: ${errors.length}`,
+  "",
+];
+
+if (errors.length === 0) {
+  lines.push("No broken URLs found.");
+} else {
+  lines.push("| File | URL | Error |");
+  lines.push("| --- | --- | --- |");
+  for (const err of errors) {
+    const filesForUrl = [...urlMap.get(err.url)].sort();
+    for (const file of filesForUrl) {
+      const fileLink = `[${file}](${file})`;
+      const urlLink = `[${err.url}](${err.url})`;
+      const errorText = err.status ? `${err.error || err.status}` : (err.error || "Unknown error");
+      lines.push(`| ${fileLink} | ${urlLink} | ${errorText.replace(/\|/g, "\\|")} |`);
+    }
+  }
+}
+
+fs.writeFileSync(outputFile, lines.join("\n") + "\n", "utf8");
+console.log(`Report written to ${outputFile}`);
+console.log(`Errors: ${errors.length}`);

--- a/web/rules/src/build.ts
+++ b/web/rules/src/build.ts
@@ -87,7 +87,7 @@ If no configuration file is found, the default configuration will be used, which
 <br><br>
 Get default configuration by running <tt>abaplint -d > abaplint.json</tt>
 <br><br>
-<a href="https://github.com/FreHu/abaplint-clean-code">abaplint-clean-code</a> contains rule
+<a href="https://github.com/mbtools/abaplint-clean-code">abaplint-clean-code</a> contains rule
 documentation as well as abaplint.json definitions which attempt to align abaplint with the official
 <a href="https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md">Clean ABAP styleguide</a>.
 

--- a/web/syntax/public/script.js
+++ b/web/syntax/public/script.js
@@ -116,7 +116,7 @@ function renderSyntax(type, name) {
     html = html + "<b>Next</b>: <a href=\"#/" + currentLanguage + "/" + type + "/" + next.name + "\">" + next.name + "</a><br>\n";
   }
 
-// html = html + "<a href=\"https://github.com/abaplint/abaplint/blob/master/src/packages/core/abap/" +
+// html = html + "<a href=\"https://github.com/abaplint/abaplint/tree/main/packages/core/src/abap/2_statements" +
 // found.type + "s/" + found.filename + "\">Source</a><br>";
 
   const use = found.using.map((e) => { return "<a href=\"#/" + currentLanguage + "/" + e + "\">" + e + "</a>"; });


### PR DESCRIPTION
I updated broken and outdated URLs. I'm not sure if you want to keep the check script in the repo.

Not changed:

- Slack invite: Doesn't work anymore (also abapGit readme). The inviter.co replacement is free and works well but you have to register and config a landing page again
- rule_page.ts contains https://schema.abaplint.org/dummy.json (404). Not sure if this should be https://schema.abaplint.org/schema.json