### PR TITLE
Fix false parser_error when macro is defined in both macros include and inline

### DIFF
--- a/packages/core/src/abap/2_statements/expand_macros.ts
+++ b/packages/core/src/abap/2_statements/expand_macros.ts
@@ -32,9 +32,11 @@ class Macros {
   }
 
   public addMacro(name: string, contents: StatementNode[], filename: string): void {
-    if (this.isMacro(name)) {
-      return;
+    const existing = this.macros[name.toUpperCase()];
+    if (existing !== undefined && existing.filename === undefined) {
+      return; // dont overwrite global macros supplied via configuration
     }
+    // macros can be redefined, the definition seen last wins
     this.macros[name.toUpperCase()] = {
       statements: contents,
       filename: filename,

--- a/packages/core/src/abap/2_statements/statement_parser.ts
+++ b/packages/core/src/abap/2_statements/statement_parser.ts
@@ -116,6 +116,17 @@ export class StatementParser {
     for (const w of wa) {
       this.process(w);
       this.categorize(w);
+    }
+
+    // macro includes are placed at the top of the class pool, so find macro
+    // definitions there first regardless of input file order, letting
+    // inline DEFINEs in the main file redefine them
+    const sequenced = [...wa].sort((a, b) => {
+      const aMacros = a.file.getFilename().endsWith(".clas.macros.abap") ? 0 : 1;
+      const bMacros = b.file.getFilename().endsWith(".clas.macros.abap") ? 0 : 1;
+      return aMacros - bMacros;
+    });
+    for (const w of sequenced) {
       macros.find(w.statements, w.file);
     }
 

--- a/packages/core/test/abap/cross_object_macros.ts
+++ b/packages/core/test/abap/cross_object_macros.ts
@@ -26,4 +26,37 @@ END-OF-DEFINITION.`);
     expect(issues.length).to.equal(0);
   });
 
+  it("macro defined in both macros include and inline, inline redefinition wins, issue 4190", () => {
+    const main = `CLASS zcl_parser_error_test DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    METHODS process.
+ENDCLASS.
+CLASS zcl_parser_error_test IMPLEMENTATION.
+  METHOD process.
+    DATA et_return TYPE STANDARD TABLE OF bapiret2.
+    DEFINE check_return.
+      LOOP AT et_return TRANSPORTING NO FIELDS WHERE type = 'A' OR type = 'E'.
+        EXIT.
+      ENDLOOP.
+    END-OF-DEFINITION.
+    check_return.
+  ENDMETHOD.
+ENDCLASS.`;
+    const macros = `DEFINE check_return.
+  LOOP AT &1 TRANSPORTING NO FIELDS WHERE type = 'A' OR type = 'E'.
+    EXIT.
+  ENDLOOP.
+END-OF-DEFINITION.`;
+
+    // the result should not depend on the order the files are added in
+    for (const files of [
+      [new MemoryFile(`zcl_parser_error_test.clas.abap`, main), new MemoryFile(`zcl_parser_error_test.clas.macros.abap`, macros)],
+      [new MemoryFile(`zcl_parser_error_test.clas.macros.abap`, macros), new MemoryFile(`zcl_parser_error_test.clas.abap`, main)],
+    ]) {
+      const reg = new Registry().addFiles(files);
+      const issues = reg.findIssues().filter(i => i.getKey() === "parser_error" || i.getKey() === "structure");
+      expect(issues.map(i => i.getMessage()).join(", ")).to.equal("");
+    }
+  });
+
 });


### PR DESCRIPTION
Closes #4190

## Problem

When a macro is defined in a class's `.clas.macros.abap` include **and** redefined inline via `DEFINE` inside a method, abaplint raised a false `parser_error` (plus a structure error) on code that activates fine in SAP.

## Root cause

Two independent things combined:

1. `Macros.addMacro()` silently ignored redefinitions — the first definition registered won, and any later `DEFINE` for the same name was dropped.
2. Which definition got registered first depended on the order the object's files happened to be fed into `StatementParser.run()` — with the macros include processed first, its `&1`-parameterized body shadowed the inline no-argument redefinition. The call site passes no arguments, so `&1` was never substituted and the expanded `LOOP AT &1 ...` failed to parse.

## Fix

- `StatementParser.run()` now collects macro definitions from `.clas.macros.abap` files first (matching the macro include's position at the top of the class pool), regardless of input file order, then the remaining files in stable order.
- `Macros.addMacro()` now lets a later `DEFINE` redefine an earlier macro, which matches ABAP behavior where the redefinition is in effect at the call site. Global macros supplied via configuration are still protected from being overwritten.

Together the issue's reproduction parses clean and the result no longer depends on file input order (verified for both orders in the new test).

## Testing

- New test in `cross_object_macros.ts` with the exact reproduction from #4190, asserted for both file orders; it fails with the reported messages ("Expected ENDMETHOD", `Statement does not exist ... "LOOP"`) without the src changes and passes with them.
- Full core test suite: 10631 passing, 0 failing.
- eslint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5CMxbrQc88XTjD8ZTb7Av