### PR TITLE
syntax check: CLASS_CONSTRUCTOR must be declared in the public section

### DIFF
--- a/packages/core/src/abap/types/class_definition.ts
+++ b/packages/core/src/abap/types/class_definition.ts
@@ -99,7 +99,7 @@ export class ClassDefinition extends Identifier implements IClassDefinition {
     this.checkEventNameConflicts(input);
     this.checkClassNameLength(input);
     this.checkMethodNameLength(input);
-    this.checkClassConstructorStatic(input);
+    this.checkClassConstructor(input);
   }
 
   public getFriends() {
@@ -188,10 +188,15 @@ export class ClassDefinition extends Identifier implements IClassDefinition {
     }
   }
 
-  private checkClassConstructorStatic(input: SyntaxInput) {
+  private checkClassConstructor(input: SyntaxInput) {
     for (const m of this.methodDefs.getAll()) {
-      if (m.getName().toUpperCase() === "CLASS_CONSTRUCTOR" && m.isStatic() === false) {
+      if (m.getName().toUpperCase() !== "CLASS_CONSTRUCTOR") {
+        continue;
+      }
+      if (m.isStatic() === false) {
         input.issues.push(syntaxIssue(input, m.getToken(), "CLASS_CONSTRUCTOR must be static"));
+      } else if (m.getVisibility() !== Visibility.Public) {
+        input.issues.push(syntaxIssue(input, m.getToken(), "CLASS_CONSTRUCTOR must be declared in the public section"));
       }
     }
   }

--- a/packages/core/test/abap/syntax/syntax.ts
+++ b/packages/core/test/abap/syntax/syntax.ts
@@ -10817,6 +10817,51 @@ ENDCLASS.`;
     expect(issues[0].getMessage()).to.contain("CLASS_CONSTRUCTOR must be static");
   });
 
+  it("class_constructor in private section, error", () => {
+    const abap = `CLASS lcl DEFINITION.
+  PRIVATE SECTION.
+    CLASS-METHODS class_constructor.
+ENDCLASS.
+CLASS lcl IMPLEMENTATION.
+  METHOD class_constructor.
+  ENDMETHOD.
+ENDCLASS.`;
+    const issues = runProgram(abap);
+    expect(issues.length).to.equals(1);
+    expect(issues[0].getMessage()).to.contain("CLASS_CONSTRUCTOR must be declared in the public section");
+  });
+
+  it("class_constructor in protected section, error", () => {
+    const abap = `CLASS lcl DEFINITION.
+  PROTECTED SECTION.
+    CLASS-METHODS class_constructor.
+ENDCLASS.
+CLASS lcl IMPLEMENTATION.
+  METHOD class_constructor.
+  ENDMETHOD.
+ENDCLASS.`;
+    const issues = runProgram(abap);
+    expect(issues.length).to.equals(1);
+    expect(issues[0].getMessage()).to.contain("CLASS_CONSTRUCTOR must be declared in the public section");
+  });
+
+  it("class_constructor in private section of global class, error", () => {
+    const abap = `CLASS zcl_foobar DEFINITION PUBLIC CREATE PUBLIC.
+  PUBLIC SECTION.
+  PRIVATE SECTION.
+    CLASS-METHODS class_constructor.
+    CLASS-DATA field TYPE i.
+ENDCLASS.
+CLASS zcl_foobar IMPLEMENTATION.
+  METHOD class_constructor.
+    field = 1.
+  ENDMETHOD.
+ENDCLASS.`;
+    const issues = runClass(abap);
+    expect(issues.length).to.equals(1);
+    expect(issues[0].getMessage()).to.contain("CLASS_CONSTRUCTOR must be declared in the public section");
+  });
+
   it("ok, select from internal tab", () => {
     const abap = `TYPES: BEGIN OF ty,
     dat TYPE d,


### PR DESCRIPTION
The static constructor may only be declared in the public visibility section of
a class. A class pool declaring `CLASS-METHODS class_constructor.` in a
`PRIVATE SECTION` or `PROTECTED SECTION` does not activate — but abaplint
reported nothing for it: `constructor_visibility_public` only looks at the
instance `constructor` (and only at global classes).

Bad, no finding before this change:

```abap
CLASS zcl_foo DEFINITION PUBLIC CREATE PUBLIC.
  PUBLIC SECTION.
  PRIVATE SECTION.
    CLASS-METHODS class_constructor.
    CLASS-DATA field TYPE i.
ENDCLASS.
```

The check is added in `ClassDefinition`, next to the existing
`CLASS_CONSTRUCTOR must be static` check, so it is reported by `check_syntax`
like the neighbouring `INTERFACES can only be declared in public sections` —
this is an activation error rather than a style preference, and unlike
`constructor_visibility_public` it applies to local classes as well.

A non-static `class_constructor` in a private section still reports only the
`must be static` message.

Tests added for a local class (private and protected) and for a global class.
Full `packages/core` suite passes.

---
🤖 Generated with [Claude Code]