### PR TITLE
feat(rules): add SMTG, JOBD, CDBO, OA2P to cloud_types and clean duplicate export

### DIFF
--- a/packages/core/src/objects/index.ts
+++ b/packages/core/src/objects/index.ts
@@ -60,7 +60,6 @@ export * from "./enhancement_implementation";
 export * from "./enhancement_spot";
 export * from "./entity_type";
 export * from "./event_binding";
-export * from "./event_binding";
 export * from "./event_consumer";
 export * from "./extension_index";
 export * from "./field_catalog";

--- a/packages/core/src/rules/cloud_types.ts
+++ b/packages/core/src/rules/cloud_types.ts
@@ -63,12 +63,14 @@ export class CloudTypes implements IRule {
       || obj instanceof Objects.CDSEntityBuffer
       || obj instanceof Objects.ApplicationLogObject
       || obj instanceof Objects.CommunicationScenario
+      || obj instanceof Objects.CustomDataBrowserObject
       || obj instanceof Objects.DataControl
       || obj instanceof Objects.Namespace
       || obj instanceof Objects.KnowledgeTransferDocument
       || obj instanceof Objects.DataDefinition
       || obj instanceof Objects.DataElement
       || obj instanceof Objects.Domain
+      || obj instanceof Objects.EmailTemplate
       || obj instanceof Objects.EventBinding
       || obj instanceof Objects.EventConsumer
       || obj instanceof Objects.FunctionGroup
@@ -81,6 +83,7 @@ export class CloudTypes implements IRule {
       || obj instanceof Objects.MaintenanceAndTransportObject
       || obj instanceof Objects.MessageClass
       || obj instanceof Objects.NumberRange
+      || obj instanceof Objects.Oauth2Profile
       || obj instanceof Objects.OutboundService
       || obj instanceof Objects.Package
       || obj instanceof Objects.RestrictionField
@@ -89,6 +92,7 @@ export class CloudTypes implements IRule {
       || obj instanceof Objects.ServiceDefinition
       || obj instanceof Objects.Table
       || obj instanceof Objects.TableType
+      || obj instanceof Objects.TechnicalJobDefinition
       || obj instanceof Objects.Transformation;
   }
 

--- a/packages/core/test/rules/cloud_types.ts
+++ b/packages/core/test/rules/cloud_types.ts
@@ -32,6 +32,26 @@ describe("Rule: cloud_types", () => {
     expect(issues.length).to.equal(0);
   });
 
+  it("SMTG, cloud enabled", async () => {
+    const issues = await findIssues("zfoobar.smtg.xml");
+    expect(issues.length).to.equal(0);
+  });
+
+  it("JOBD, cloud enabled", async () => {
+    const issues = await findIssues("zfoobar.jobd.xml");
+    expect(issues.length).to.equal(0);
+  });
+
+  it("CDBO, cloud enabled", async () => {
+    const issues = await findIssues("zfoobar.cdbo.xml");
+    expect(issues.length).to.equal(0);
+  });
+
+  it("OA2P, cloud enabled", async () => {
+    const issues = await findIssues("zfoobar.oa2p.xml");
+    expect(issues.length).to.equal(0);
+  });
+
   it("PROG, not cloud enabled", async () => {
     const issues = await findIssues("zfoobar.prog.abap");
     expect(issues.length).to.equal(1);


### PR DESCRIPTION
## Summary

- **Add Modern ABAP Cloud Object Types to `cloud_types`**:
  - `EmailTemplate` (`SMTG`) - SAP Mail & Email Templates
  - `TechnicalJobDefinition` (`JOBD`) - Application Job Definitions
  - `CustomDataBrowserObject` (`CDBO`) - Custom Data Browser
  - `Oauth2Profile` (`OA2P`) - OAuth 2.0 Client Profiles
- **Cleanup**: Remove duplicate export in `packages/core/src/objects/index.ts`.
- **Tests**: Add unit test cases for the new cloud object types in `packages/core/test/rules/cloud_types.ts`. All 10,718 tests passing and ESLint clean.
