### PR TITLE
line_break_style: also check XML files

### DIFF
--- a/packages/core/scripts/schema.json
+++ b/packages/core/scripts/schema.json
@@ -2761,7 +2761,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Enforces LF as newlines in ABAP files\n\nabapGit does not work with CRLF\nTags: Whitespace, SingleFile\nhttps://rules.abaplint.org/line_break_style"
+              "description": "Enforces LF as newlines in ABAP and XML files\n\nabapGit does not work with CRLF\nTags: Whitespace, SingleFile\nhttps://rules.abaplint.org/line_break_style"
             },
             "line_length": {
               "anyOf": [
@@ -4873,7 +4873,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Enforces LF as newlines in ABAP files\n\nabapGit does not work with CRLF\nTags: Whitespace, SingleFile\nhttps://rules.abaplint.org/line_break_style"
+              "description": "Enforces LF as newlines in ABAP and XML files\n\nabapGit does not work with CRLF\nTags: Whitespace, SingleFile\nhttps://rules.abaplint.org/line_break_style"
             },
             "line_length": {
               "anyOf": [

--- a/packages/core/src/rules/line_break_style.ts
+++ b/packages/core/src/rules/line_break_style.ts
@@ -3,6 +3,7 @@ import {BasicRuleConfig} from "./_basic_rule_config";
 import {IObject} from "../objects/_iobject";
 import {IRule, IRuleMetadata, RuleTag} from "./_irule";
 import {IRegistry} from "../_iregistry";
+import {MIMEObject, WebMIME} from "../objects";
 
 export class LineBreakStyleConf extends BasicRuleConfig {
 }
@@ -13,10 +14,11 @@ export class LineBreakStyle implements IRule {
   public getMetadata(): IRuleMetadata {
     return {
       key: "line_break_style",
-      title: "Makes sure line breaks are consistent in the ABAP code",
-      shortDescription: `Enforces LF as newlines in ABAP files
+      title: "Makes sure line breaks are consistent",
+      shortDescription: `Enforces LF as newlines in ABAP and XML files
 
 abapGit does not work with CRLF`,
+      extendedInformation: `SMIM and W3MI files are not checked.`,
       tags: [RuleTag.Whitespace, RuleTag.SingleFile],
     };
   }
@@ -36,8 +38,13 @@ abapGit does not work with CRLF`,
   public run(obj: IObject): Issue[] {
     const output: Issue[] = [];
 
+    if (obj instanceof MIMEObject || obj instanceof WebMIME) {
+      return output;
+    }
+
     for (const file of obj.getFiles()) {
-      if (file.getFilename().endsWith(".abap")) {
+      const filename = file.getFilename();
+      if (filename.endsWith(".abap") || filename.endsWith(".xml")) {
         const rows = file.getRawRows();
         for (let i = 0; i < rows.length; i++) {
           if (rows[i].endsWith("\r") === true) {

--- a/packages/core/test/rules/line_break_style.ts
+++ b/packages/core/test/rules/line_break_style.ts
@@ -1,5 +1,8 @@
+import {expect} from "chai";
 import {testRule} from "./_utils";
 import {LineBreakStyle} from "../../src/rules";
+import {MemoryFile} from "../../src/files/memory_file";
+import {Registry} from "../../src/registry";
 
 const tests = [
   {abap: "WRITE: / 'abc'.", cnt: 0},
@@ -11,3 +14,46 @@ const tests = [
 ];
 
 testRule(tests, LineBreakStyle);
+
+const xml = `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZFOO</NAME>
+    <SUBC>1</SUBC>
+    <FIXPT>X</FIXPT>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+const crlf = xml.replace(/\n/g, "\r\n");
+
+function runFile(filename: string, contents: string) {
+  const reg = new Registry().addFile(new MemoryFile(filename, contents)).parse();
+  return new LineBreakStyle().initialize(reg).run(reg.getFirstObject()!);
+}
+
+describe("rule, line_break_style, xml", () => {
+  it("reports XML files with CRLF", () => {
+    const issues = runFile("zfoo.prog.xml", crlf);
+    expect(issues).to.have.length(1);
+    expect(issues[0].getMessage()).to.equal("Line contains carriage return");
+  });
+
+  it("accepts XML files with LF", () => {
+    const issues = runFile("zfoo.prog.xml", xml);
+    expect(issues).to.have.length(0);
+  });
+
+  it("skips W3MI files", () => {
+    const reg = new Registry()
+      .addFile(new MemoryFile("zfoo.w3mi.xml", crlf))
+      .addFile(new MemoryFile("zfoo.w3mi.data.xml", crlf))
+      .parse();
+    const issues = new LineBreakStyle().initialize(reg).run(reg.getFirstObject()!);
+    expect(issues).to.have.length(0);
+  });
+});


### PR DESCRIPTION
The rule's own shortDescription names abapGit as the reason: "abapGit does not work with CRLF". But run() only ever looked at files ending in .abap, so a .clas.xml, .intf.xml or any other abapGit serialization sidecar with CRLF passed unnoticed. Measured on 2.120.33 with line_break_style explicitly enabled: a CRLF .intf.xml produced zero findings. That is the same defect the rule was written for, just on the other half of what abapGit serializes.

The filter now accepts .xml alongside .abap, and MIME objects are skipped the same way whitespace_end skips them, with the same extendedInformation: a .w3mi.data.xml is content rather than a serialization and may legitimately contain CRLF.

Title, shortDescription and the generated scripts/schema.json are updated to match the widened scope.