### PR TITLE
feat: add support for compositions in cds_field_order rule tests

### DIFF
--- a/packages/core/src/rules/cds_field_order.ts
+++ b/packages/core/src/rules/cds_field_order.ts
@@ -4,7 +4,7 @@ import {IObject} from "../objects/_iobject";
 import {IRegistry} from "../_iregistry";
 import {BasicRuleConfig} from "./_basic_rule_config";
 import {DataDefinition} from "../objects";
-import {CDSSelect, CDSElement, CDSAssociation, CDSAs, CDSName, CDSRelation} from "../cds/expressions";
+import {CDSSelect, CDSElement, CDSAssociation, CDSComposition, CDSAs, CDSName, CDSRelation} from "../cds/expressions";
 import {ExpressionNode} from "../abap/nodes/expression_node";
 
 export class CDSFieldOrderConf extends BasicRuleConfig {
@@ -103,7 +103,8 @@ export class CDSFieldOrder implements IRule {
 
   private getAssociationNames(tree: ExpressionNode): Set<string> {
     const names = new Set<string>();
-    for (const assoc of tree.findAllExpressions(CDSAssociation)) {
+    const found = [...tree.findAllExpressions(CDSAssociation), ...tree.findAllExpressions(CDSComposition)];
+    for (const assoc of found) {
       const relation = assoc.findDirectExpression(CDSRelation);
       if (relation === undefined) {
         continue;

--- a/packages/core/test/rules/cds_field_order.ts
+++ b/packages/core/test/rules/cds_field_order.ts
@@ -93,6 +93,22 @@ describe("Rule: cds_field_order", () => {
     expect(issues.length).to.equal(0);
   });
 
+  it("no issues, compositions after associations", async () => {
+    const cds = `define view entity test as select from source
+  association [1..1] to target1 as _Assoc on $projection.field1 = _Assoc.field1
+  composition [0..*] of target3 as _Comp
+{
+  key id,
+  key id2,
+  field1,
+  field2,
+  _Assoc,
+  _Comp
+}`;
+    const issues = await findIssues(cds);
+    expect(issues.length).to.equal(0);
+  });
+
   it("no issues, single key field only", async () => {
     const cds = `define view entity test as select from source {
   key id


### PR DESCRIPTION
Compositions are now treated like associations in `cds_field_order`.

Previously only `association` aliases were collected, so a `composition [0..*] of ... as _Comp`
listed at the end of the field list was seen as a regular field — producing a false "Associations must be listed last" finding on every field after it.

`getAssociationNames` now also scans `CDSComposition` nodes.