### PR TITLE
fix: support namespaced prefix in cds_naming rule

### DIFF
--- a/packages/core/src/rules/cds_naming.ts
+++ b/packages/core/src/rules/cds_naming.ts
@@ -5,7 +5,6 @@ import {IRegistry} from "../_iregistry";
 import {BasicRuleConfig} from "./_basic_rule_config";
 import {DataDefinition} from "../objects";
 import {CDSDefineView, CDSDefineAbstract, CDSDefineCustom, CDSDefineTableFunction, CDSExtendView, CDSDefineProjection} from "../cds/expressions";
-import {CDSName} from "../cds/expressions/cds_name";
 import {ExpressionNode} from "../abap/nodes/expression_node";
 
 export class CDSNamingConf extends BasicRuleConfig {
@@ -82,7 +81,7 @@ https://help.sap.com/docs/SAP_S4HANA_ON-PREMISE/ee6ff9b281d8448f96b4fe6c89f2bdc8
       return [];
     }
 
-    const name = this.getCDSName(tree);
+    const name = o.getDefinitionName();
     if (name === undefined) {
       return [];
     }
@@ -101,14 +100,6 @@ https://help.sap.com/docs/SAP_S4HANA_ON-PREMISE/ee6ff9b281d8448f96b4fe6c89f2bdc8
     }
 
     return [];
-  }
-
-  private getCDSName(tree: ExpressionNode): string | undefined {
-    const nameNodes = tree.findDirectExpressions(CDSName);
-    if (nameNodes.length > 0) {
-      return nameNodes[0].getFirstToken().getStr();
-    }
-    return undefined;
   }
 
   private getAllowedPrefixes(tree: ExpressionNode): string[] {

--- a/packages/core/test/rules/cds_naming.ts
+++ b/packages/core/test/rules/cds_naming.ts
@@ -3,11 +3,15 @@ import {Registry} from "../../src/registry";
 import {expect} from "chai";
 import {Issue} from "../../src/issue";
 import {CDSNaming} from "../../src/rules";
+import {CDSNamingConf} from "../../src/rules/cds_naming";
 
-async function findIssues(cds: string): Promise<readonly Issue[]> {
+async function findIssues(cds: string, config?: CDSNamingConf): Promise<readonly Issue[]> {
   const reg = new Registry().addFile(new MemoryFile("foobar.ddls.asddls", cds));
   await reg.parseAsync();
   const rule = new CDSNaming();
+  if (config !== undefined) {
+    rule.setConfig(config);
+  }
   return rule.initialize(reg).run(reg.getFirstObject()!);
 }
 
@@ -108,4 +112,26 @@ describe("Rule: cds_naming", () => {
     expect(issues.length).to.equal(0);
   });
 
+  it("error, namespaced name does not match the plain configured prefix", async () => {
+    const cds = `define view entity /FOO/ZI_MY_VIEW as select from source { key id }`;
+    const issues = await findIssues(cds);
+    expect(issues.length).to.equal(1);
+    expect(issues[0].getMessage()).to.contain(`"/FOO/ZI_MY_VIEW"`);
+  });
+
+  it("no issues, namespaced name, configured prefix includes namespace", async () => {
+    const cds = `define view entity /FOO/I_MY_VIEW as select from source { key id }`;
+    const config = new CDSNamingConf();
+    config.basicInterfaceView = "/FOO/I_";
+    config.compositeInterfaceView = "/FOO/I_";
+    const issues = await findIssues(cds, config);
+    expect(issues.length).to.equal(0);
+  });
+
+  it("error, namespaced name without valid prefix", async () => {
+    const cds = `define view entity /FOO/MY_VIEW as select from source { key id }`;
+    const issues = await findIssues(cds);
+    expect(issues.length).to.equal(1);
+    expect(issues[0].getMessage()).to.contain(`"/FOO/MY_VIEW"`);
+  });
 });


### PR DESCRIPTION
`cds_naming` read the entity name via `getFirstToken()`, but a namespaced name lexes into multiple tokens (`/`, `FOO`, `/`, `I_BAR`), so the rule only ever saw `/` and always failed the prefix check.
`DataDefinition.getDefinitionName()` already returns the full name, so the local helper is dropped in favour of it.