### PR TITLE
Downport: hoist a 702 built-in out of the generated WITH KEY operand

### DIFF
--- a/packages/core/src/rules/downport.ts
+++ b/packages/core/src/rules/downport.ts
@@ -433,6 +433,11 @@ Make sure to test the downported code, it might not always be completely correct
       return found;
     }
 
+    found = this.outlineTableExpressionKeyBuiltin(low, high, lowFile, highSyntax);
+    if (found) {
+      return found;
+    }
+
     found = this.assignWithTable(low, high, lowFile);
     if (found) {
       return found;
@@ -1230,6 +1235,79 @@ ${indentation}`);
       condition += c.concatTokens() + " ";
     }
     return condition;
+  }
+
+  /** A built-in function is only recognized as one in an operand position that admits an
+   * expression, and "WITH KEY comp = ..." does not become such a position until v740. The
+   * table expression rewrites carry the key operand over verbatim, so
+   * "tab[ comp = to_upper( x ) ]" downports to a READ TABLE that a 702 or 731 compiler can
+   * only read as a functional method call - "method TO_UPPER is unknown", reported as a
+   * SYNTAX_ERROR of the whole class pool. Hoist the call into a variable first, an
+   * assignment IS an expression position at 702.
+   *
+   * Built-ins that predate 702 (lines, strlen, numofchar, ...) carry no release in
+   * BuiltIn.methods; they are accepted in the operand as they are and stay untouched. So do
+   * functional method calls, which are exactly the reading that makes the built-in fail, and
+   * the INDEX operand of "tab[ 1 ]", which is not a key operand. */
+  private outlineTableExpressionKeyBuiltin(low: StatementNode, high: StatementNode, lowFile: ABAPFile,
+                                           highSyntax: ISyntaxResult): Issue | undefined {
+    if (!(low.get() instanceof Unknown)) {
+      return undefined;
+    }
+
+    for (const tableExpression of high.findAllExpressionsRecursive(Expressions.TableExpression)) {
+      let afterComponent = false;
+      for (const child of tableExpression.getChildren()) {
+        if (child.get() instanceof Expressions.ComponentChainSimple) {
+          afterComponent = true;
+          continue;
+        } else if (afterComponent === false
+            || !(child.get() instanceof Expressions.Source)
+            || !(child instanceof ExpressionNode)) {
+          continue;
+        }
+
+        const type = this.builtinReturnType(child, lowFile, highSyntax);
+        if (type === undefined) {
+          continue;
+        }
+
+        const uniqueName = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax);
+        const indentation = " ".repeat(high.getFirstToken().getStart().getCol() - 1);
+        const code = `DATA ${uniqueName} TYPE ${type}.\n` +
+          indentation + `${uniqueName} = ${child.concatTokens()}.\n` +
+          indentation;
+
+        const fix1 = EditHelper.insertAt(lowFile, high.getFirstToken().getStart(), code);
+        const fix2 = EditHelper.replaceRange(lowFile, child.getFirstToken().getStart(), child.getLastToken().getEnd(), uniqueName);
+        const fix = EditHelper.merge(fix2, fix1);
+
+        return Issue.atToken(lowFile, child.getFirstToken(), "Outline built-in function in table expression key",
+                             this.getMetadata().key, this.conf.severity, fix);
+      }
+    }
+
+    return undefined;
+  }
+
+  /** the ABAP type returned by the built-in function this Source starts with, or undefined
+   * if it does not start with one, or with one that predates 702 */
+  private builtinReturnType(source: ExpressionNode, lowFile: ABAPFile, highSyntax: ISyntaxResult): string | undefined {
+    const spag = highSyntax.spaghetti.lookupPosition(source.getFirstToken().getStart(), lowFile.getFilename());
+
+    for (const r of spag?.getData().references || []) {
+      if (r.referenceType !== ReferenceType.BuiltinMethodReference
+          || r.position.getStart().equals(source.getFirstToken().getStart()) === false) {
+        continue;
+      }
+      const name = r.position.getName().toUpperCase();
+      if (BuiltIn.methods[name]?.release === undefined) {
+        return undefined;
+      }
+      return BuiltIn.searchBuiltin(name)?.getParameters().getReturning()?.getType().toABAP();
+    }
+
+    return undefined;
   }
 
   private outlineCatchSimple(node: StatementNode, lowFile: ABAPFile): Issue | undefined {

--- a/packages/core/test/rules/downport.ts
+++ b/packages/core/test/rules/downport.ts
@@ -6099,4 +6099,152 @@ SELECT * FROM sdfsdfsdf INTO CORRESPONDING FIELDS OF TABLE result
     testFixAll(abap, expected);
   });
 
+  it("table expression key, hoist 702 built-in out of the generated WITH KEY operand", async () => {
+    const abap = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_name TYPE string.
+  IF line_exists( lt_list[ table_line = to_upper( lv_name ) ] ).
+    WRITE / 'hello'.
+  ENDIF.
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_name TYPE string.
+  DATA temp1 TYPE string.
+  temp1 = to_upper( lv_name ).
+  DATA temp2 LIKE sy-subrc.
+  READ TABLE lt_list WITH KEY table_line = temp1 TRANSPORTING NO FIELDS.
+  temp2 = sy-subrc.
+  IF temp2 = 0.
+    WRITE / 'hello'.
+  ENDIF.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression key, hoist 702 built-in, plain table expression", async () => {
+    const abap = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_name TYPE string.
+  DATA lv_row TYPE string.
+  lv_row = lt_list[ table_line = to_upper( lv_name ) ].
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_name TYPE string.
+  DATA lv_row TYPE string.
+  DATA temp1 TYPE string.
+  temp1 = to_upper( lv_name ).
+  DATA temp2 LIKE LINE OF lt_list.
+  DATA temp3 LIKE sy-tabix.
+  temp3 = sy-tabix.
+  READ TABLE lt_list WITH KEY table_line = temp1 INTO temp2.
+  sy-tabix = temp3.
+  IF sy-subrc <> 0.
+    RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+  ENDIF.
+  lv_row = temp2.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression key, built-in older than 702 stays in the operand", async () => {
+    const abap = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF i WITH DEFAULT KEY.
+  IF line_exists( lt_list[ table_line = lines( lt_list ) ] ).
+    WRITE / 'hello'.
+  ENDIF.
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF i WITH DEFAULT KEY.
+  DATA temp1 LIKE sy-subrc.
+  READ TABLE lt_list WITH KEY table_line = lines( lt_list ) TRANSPORTING NO FIELDS.
+  temp1 = sy-subrc.
+  IF temp1 = 0.
+    WRITE / 'hello'.
+  ENDIF.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression key, functional method call stays in the operand", async () => {
+    const abap = `CLASS lcl DEFINITION.
+  PUBLIC SECTION.
+    METHODS name RETURNING VALUE(rv_name) TYPE string.
+    METHODS run.
+ENDCLASS.
+CLASS lcl IMPLEMENTATION.
+  METHOD name.
+  ENDMETHOD.
+  METHOD run.
+    DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+    IF line_exists( lt_list[ table_line = me->name( ) ] ).
+      WRITE / 'hello'.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.`;
+
+    const expected = `CLASS lcl DEFINITION.
+  PUBLIC SECTION.
+    METHODS name RETURNING VALUE(rv_name) TYPE string.
+    METHODS run.
+ENDCLASS.
+CLASS lcl IMPLEMENTATION.
+  METHOD name.
+  ENDMETHOD.
+  METHOD run.
+    DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+    DATA temp1 LIKE sy-subrc.
+    READ TABLE lt_list WITH KEY table_line = me->name( ) TRANSPORTING NO FIELDS.
+    temp1 = sy-subrc.
+    IF temp1 = 0.
+      WRITE / 'hello'.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression key, built-in in the INDEX operand is not a key operand", async () => {
+    const abap = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_row TYPE string.
+  lv_row = lt_list[ lines( lt_list ) ].
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_row TYPE string.
+  DATA temp1 LIKE LINE OF lt_list.
+  DATA temp2 LIKE sy-tabix.
+  temp2 = sy-tabix.
+  READ TABLE lt_list INDEX lines( lt_list ) INTO temp1.
+  sy-tabix = temp2.
+  IF sy-subrc <> 0.
+    RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+  ENDIF.
+  lv_row = temp1.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression key, no downport at v740sp02", async () => {
+    const issues = await findIssues(`FORM bar.
+  DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+  DATA lv_name TYPE string.
+  IF line_exists( lt_list[ table_line = to_upper( lv_name ) ] ).
+    WRITE / 'hello'.
+  ENDIF.
+ENDFORM.`, Version.v740sp02);
+    expect(issues.length).to.equal(0);
+  });
+
 });


### PR DESCRIPTION
## The problem

A built-in function is only recognized as one in an operand position that admits
an expression, and `WITH KEY comp = ...` does not become such a position until
v740. The table expression rewrites carry the key operand over verbatim:

```abap
IF NOT line_exists( mt_names[ table_line = to_upper( is_node ) ] ).
```

downports at v702 to

```abap
READ TABLE mt_names WITH KEY table_line = to_upper( is_node ) TRANSPORTING NO FIELDS.
```

A 702 or 731 compiler has only one other reading of `name( … )` available to it,
so it takes it as a functional method call:

```
Die Methode "TO_UPPER" ist unbekannt bzw. PROTECTED oder PRIVATE.
```

reported as a `SYNTAX_ERROR` of the whole class pool.

## Why the rewrite is not the place to fix it

Four paths build such an operand — `line_exists`, `line_index`, the plain table
expression, and the `ASSIGN` form. All four reproduce this (measured before
touching anything), and patching each emitter means four near-identical changes.

So the hoist happens **before** them instead, as its own step:

```abap
DATA temp1 TYPE string.
temp1 = to_upper( is_node ).
DATA temp2 LIKE sy-subrc.
READ TABLE mt_names WITH KEY table_line = temp1 TRANSPORTING NO FIELDS.
```

An assignment IS an expression position at 702, so every one of the four then
carries the temporary over correctly — with no change to any of them.

## Scope

The temporary's type is the built-in's own return type. Whether a built-in needs
the hoist at all is read from `release` in `BuiltIn.methods` rather than from a
hand-written list: the ones that predate 702 carry none.

| | |
|---|---|
| `to_upper`, `condense`, `substring`, … | `release: v702` → hoisted |
| `lines`, `strlen`, `numofchar` | no `release` → left in the operand |

Functional method calls stay untouched — that reading is precisely what makes the
built-in fail, so they are accepted there as they are. So does the `INDEX` operand
of `tab[ 1 ]`, which is not a key operand.

No version check is needed: the step is guarded on `low.get() instanceof Unknown`
like its neighbours, and from v740 on the statement parses at the target version,
so no downport happens at all. Covered by a test.

## Tests

Six, in `test/rules/downport.ts`: the reported case, the plain table expression,
and four that must not change — a pre-702 built-in, a functional method call, the
`INDEX` operand, and v740sp02 producing no issue.

Whole core suite **10929 → 10935 passing, 0 failing**; `npm run lint` clean. The
diff is additive only, 78 lines of source and 148 of test.

## Where this bites

abap2UI5#2664: a 7.31 system dumped `SYNTAX_ERROR` on the framework's client
class, taking every abap2UI5 application on that system down. The source is valid
at the v750 target, abaplint is green on it, the transpiled suite is green, and
the 702 config lints the downported branch green as well — four checks passed on
a class that cannot be activated. It was repaired there by hoisting the call by
hand and guarding the shape with a source gate; this removes the need for both.