### PR TITLE
Downport: outline a table expression with ASSIGNING, not INTO

### DIFF
--- a/packages/core/src/rules/downport.ts
+++ b/packages/core/src/rules/downport.ts
@@ -1185,15 +1185,19 @@ ${indentation}${uniqueName} = ${source.concatTokens()}.\n${indentation}`);
 
       const condition = this.tableCondition(tableExpression);
 
-      const uniqueName = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax);
+      // ASSIGNING, not INTO: from v740 a table expression in a read position addresses the
+      // row rather than copying it, so "REF #( tab[ i ]-comp )" and "ASSIGN tab[ i ]-comp"
+      // hand back an address INTO a work area would not preserve. The write path
+      // (moveWithTableTarget) already lowers to ASSIGNING for the same reason.
+      const uniqueName = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax, true);
       const tabixBackup = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax);
       const indentation = " ".repeat(high.getFirstToken().getStart().getCol() - 1);
       const firstToken = high.getFirstToken();
       // note that the tabix restore should be done before throwing the exception
-      const fix1 = EditHelper.insertAt(lowFile, firstToken.getStart(), `DATA ${uniqueName} LIKE LINE OF ${pre}.
+      const fix1 = EditHelper.insertAt(lowFile, firstToken.getStart(), `FIELD-SYMBOLS ${uniqueName} LIKE LINE OF ${pre}.
 ${indentation}DATA ${tabixBackup} LIKE sy-tabix.
 ${indentation}${tabixBackup} = sy-tabix.
-${indentation}READ TABLE ${pre} ${condition}INTO ${uniqueName}.
+${indentation}READ TABLE ${pre} ${condition}ASSIGNING ${uniqueName}.
 ${indentation}sy-tabix = ${tabixBackup}.
 ${indentation}IF sy-subrc <> 0.
 ${indentation}  RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
@@ -2035,8 +2039,7 @@ CONSTANTS: BEGIN OF ${structureName},\n`;
       return undefined;
     }
 
-    let uniqueName = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax);
-    uniqueName = `<${uniqueName}>`;
+    const uniqueName = this.uniqueName(high.getFirstToken().getStart(), lowFile.getFilename(), highSyntax, true);
 
     const tName = target.concatTokens().split("[")[0];
     const condition = this.tableCondition(tableExpression);
@@ -3130,12 +3133,17 @@ ${indentation}    output = ${uniqueName}.\n`;
     return undefined;
   }
 
-  private uniqueName(position: Position, filename: string, highSyntax: ISyntaxResult): string {
+  /** a FIELD-SYMBOLS declaration is known to the scope under its bracketed spelling, so
+   * the collision check has to use that spelling too - otherwise a second outline in the
+   * same method is handed a name that is already taken and the result does not compile */
+  private uniqueName(position: Position, filename: string, highSyntax: ISyntaxResult, fieldSymbol = false): string {
+    const decorate = (name: string) => fieldSymbol === true ? `<${name}>` : name;
+
     const spag = highSyntax.spaghetti.lookupPosition(position, filename);
     if (spag === undefined) {
       const name = "temprr" + this.counter;
       this.counter++;
-      return name;
+      return decorate(name);
     }
 
     let postfix = "";
@@ -3146,7 +3154,7 @@ ${indentation}    output = ${uniqueName}.\n`;
     }
 
     while (true) {
-      const name = "temp" + this.counter + postfix;
+      const name = decorate("temp" + this.counter + postfix);
       const exists = this.existsRecursive(spag, name);
       this.counter++;
       if (exists === false) {

--- a/packages/core/test/rules/downport.ts
+++ b/packages/core/test/rules/downport.ts
@@ -1051,15 +1051,15 @@ ENDFORM.`;
 ENDFORM.`;
 
     const expected = `FORM bar.
-  DATA temp1 LIKE LINE OF lt_lognumbers.
+  FIELD-SYMBOLS <temp1> LIKE LINE OF lt_lognumbers.
   DATA temp2 LIKE sy-tabix.
   temp2 = sy-tabix.
-  READ TABLE lt_lognumbers INDEX 1 INTO temp1.
+  READ TABLE lt_lognumbers INDEX 1 ASSIGNING <temp1>.
   sy-tabix = temp2.
   IF sy-subrc <> 0.
     RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
   ENDIF.
-  rv_lognumber = temp1-lognumber.
+  rv_lognumber = <temp1>-lognumber.
 ENDFORM.`;
 
     testFix(abap, expected);
@@ -1815,15 +1815,15 @@ TYPES: BEGIN OF ty_type,
          foo TYPE i,
        END OF ty_type.
 DATA tab TYPE STANDARD TABLE OF ty_type WITH DEFAULT KEY.
-DATA temp1 LIKE LINE OF tab.
+FIELD-SYMBOLS <temp1> LIKE LINE OF tab.
 DATA temp2 LIKE sy-tabix.
 temp2 = sy-tabix.
-READ TABLE tab WITH KEY foo = 2 INTO temp1.
+READ TABLE tab WITH KEY foo = 2 ASSIGNING <temp1>.
 sy-tabix = temp2.
 IF sy-subrc <> 0.
   RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
 ENDIF.
-WRITE temp1-foo.`;
+WRITE <temp1>-foo.`;
 
     testFix(abap, expected);
   });
@@ -2101,15 +2101,15 @@ ENDTRY.`;
   DATA(lv_text) = it_operations[ activity = 2 ]-description.`;
     const expected = `
   DATA it_operations TYPE voided.
-  DATA temp1 LIKE LINE OF it_operations.
+  FIELD-SYMBOLS <temp1> LIKE LINE OF it_operations.
   DATA temp2 LIKE sy-tabix.
   temp2 = sy-tabix.
-  READ TABLE it_operations WITH KEY activity = 2 INTO temp1.
+  READ TABLE it_operations WITH KEY activity = 2 ASSIGNING <temp1>.
   sy-tabix = temp2.
   IF sy-subrc <> 0.
     RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
   ENDIF.
-  DATA(lv_text) = temp1-description.`;
+  DATA(lv_text) = <temp1>-description.`;
     testFix(abap, expected);
   });
 
@@ -2616,15 +2616,15 @@ ENDCLASS.`;
         WITH UNIQUE KEY plain
         WITH UNIQUE HASHED KEY cipher_key COMPONENTS cipher.
     DATA foo TYPE c LENGTH 1.
-    DATA temp1 LIKE LINE OF cipher_dict.
+    FIELD-SYMBOLS <temp1> LIKE LINE OF cipher_dict.
     DATA temp2 LIKE sy-tabix.
     temp2 = sy-tabix.
-    READ TABLE cipher_dict WITH TABLE KEY cipher_key COMPONENTS cipher = '' INTO temp1.
+    READ TABLE cipher_dict WITH TABLE KEY cipher_key COMPONENTS cipher = '' ASSIGNING <temp1>.
     sy-tabix = temp2.
     IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
     ENDIF.
-    foo = temp1-plain.`;
+    foo = <temp1>-plain.`;
     testFix(abap, expected);
   });
 
@@ -6138,15 +6138,15 @@ ENDFORM.`;
   DATA lv_row TYPE string.
   DATA temp1 TYPE string.
   temp1 = to_upper( lv_name ).
-  DATA temp2 LIKE LINE OF lt_list.
-  DATA temp3 LIKE sy-tabix.
-  temp3 = sy-tabix.
-  READ TABLE lt_list WITH KEY table_line = temp1 INTO temp2.
-  sy-tabix = temp3.
+  FIELD-SYMBOLS <temp1> LIKE LINE OF lt_list.
+  DATA temp2 LIKE sy-tabix.
+  temp2 = sy-tabix.
+  READ TABLE lt_list WITH KEY table_line = temp1 ASSIGNING <temp1>.
+  sy-tabix = temp2.
   IF sy-subrc <> 0.
     RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
   ENDIF.
-  lv_row = temp2.
+  lv_row = <temp1>.
 ENDFORM.`;
 
     testFixAll(abap, expected);
@@ -6222,15 +6222,15 @@ ENDFORM.`;
     const expected = `FORM bar.
   DATA lt_list TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
   DATA lv_row TYPE string.
-  DATA temp1 LIKE LINE OF lt_list.
+  FIELD-SYMBOLS <temp1> LIKE LINE OF lt_list.
   DATA temp2 LIKE sy-tabix.
   temp2 = sy-tabix.
-  READ TABLE lt_list INDEX lines( lt_list ) INTO temp1.
+  READ TABLE lt_list INDEX lines( lt_list ) ASSIGNING <temp1>.
   sy-tabix = temp2.
   IF sy-subrc <> 0.
     RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
   ENDIF.
-  lv_row = temp1.
+  lv_row = <temp1>.
 ENDFORM.`;
 
     testFixAll(abap, expected);
@@ -6245,6 +6245,71 @@ ENDFORM.`;
   ENDIF.
 ENDFORM.`, Version.v740sp02);
     expect(issues.length).to.equal(0);
+  });
+
+  it("table expression, outlined with ASSIGNING so a component keeps the row address", async () => {
+    const abap = `FORM bar.
+  TYPES: BEGIN OF ty_row, name TYPE string, END OF ty_row.
+  DATA lt_tab TYPE STANDARD TABLE OF ty_row WITH DEFAULT KEY.
+  DATA lr_ref TYPE REF TO data.
+  lr_ref = REF #( lt_tab[ 1 ]-name ).
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  TYPES: BEGIN OF ty_row, name TYPE string, END OF ty_row.
+  DATA lt_tab TYPE STANDARD TABLE OF ty_row WITH DEFAULT KEY.
+  DATA lr_ref TYPE REF TO data.
+  FIELD-SYMBOLS <temp1> TYPE ty_row-name.
+  FIELD-SYMBOLS <temp2> LIKE LINE OF lt_tab.
+  DATA temp3 LIKE sy-tabix.
+  temp3 = sy-tabix.
+  READ TABLE lt_tab INDEX 1 ASSIGNING <temp2>.
+  sy-tabix = temp3.
+  IF sy-subrc <> 0.
+    RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+  ENDIF.
+  ASSIGN <temp2>-name TO <temp1>.
+IF sy-subrc <> 0.
+  RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+ENDIF.
+GET REFERENCE OF <temp1> INTO lr_ref.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
+  });
+
+  it("table expression, two outlines in one statement get distinct field symbols", async () => {
+    const abap = `FORM bar.
+  TYPES: BEGIN OF ty_row, name TYPE string, END OF ty_row.
+  DATA lt_tab TYPE STANDARD TABLE OF ty_row WITH DEFAULT KEY.
+  DATA lv_text TYPE string.
+  lv_text = |{ lt_tab[ 1 ]-name }{ lt_tab[ 2 ]-name }|.
+ENDFORM.`;
+
+    const expected = `FORM bar.
+  TYPES: BEGIN OF ty_row, name TYPE string, END OF ty_row.
+  DATA lt_tab TYPE STANDARD TABLE OF ty_row WITH DEFAULT KEY.
+  DATA lv_text TYPE string.
+  FIELD-SYMBOLS <temp1> LIKE LINE OF lt_tab.
+  DATA temp2 LIKE sy-tabix.
+  temp2 = sy-tabix.
+  READ TABLE lt_tab INDEX 1 ASSIGNING <temp1>.
+  sy-tabix = temp2.
+  IF sy-subrc <> 0.
+    RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+  ENDIF.
+  FIELD-SYMBOLS <temp2> LIKE LINE OF lt_tab.
+  DATA temp3 LIKE sy-tabix.
+  temp3 = sy-tabix.
+  READ TABLE lt_tab INDEX 2 ASSIGNING <temp2>.
+  sy-tabix = temp3.
+  IF sy-subrc <> 0.
+    RAISE EXCEPTION TYPE cx_sy_itab_line_not_found.
+  ENDIF.
+  lv_text = |{ <temp1>-name }{ <temp2>-name }|.
+ENDFORM.`;
+
+    testFixAll(abap, expected);
   });
 
 });


### PR DESCRIPTION
## The problem

From v740 a table expression in a read position **addresses the row** — it does
not copy it, which is why `tab[ i ]-comp = x` is legal and why `REF #( tab[ i ] )`
hands back a reference into the table. The read path outlines it into a work area:

```abap
lr = REF #( mt_tab[ 1 ]-name ).
```

```abap
DATA temp1 LIKE LINE OF mt_tab.
READ TABLE mt_tab INDEX 1 INTO temp1.     " <-- a COPY
ASSIGN temp1-name TO <temp2>.
GET REFERENCE OF <temp2> INTO lr.
```

For a value read the two are indistinguishable. For anything that takes the
value's **address** — `REF #( )`, `ASSIGN`, a pass-by-reference actual parameter —
they are not: the reference points at a temporary that nothing else can reach.

## The rule already knows this

`moveWithTableTarget`, the write path, emits

```abap
FIELD-SYMBOLS <temp1> LIKE LINE OF mt_tab.
READ TABLE mt_tab INDEX 1 ASSIGNING <temp1>.
```

which is exactly why `tab[ i ] = x`, `REF #( tab[ i ] )` and
`ASSIGN tab[ i ] TO <row>` survive the downport, and only the component-level
read does not. `replaceTableExpression` now emits the same shape.

## The companion change, and why it is load-bearing

A `FIELD-SYMBOLS` declaration is known to the scope under its **bracketed**
spelling:

```
findVariable("temp1")   -> not found
findVariable("<temp1>") -> found
```

so `uniqueName` has to check that spelling. Without it a second outline in the
same method is handed a name that is already taken. It does not show on two
separate statements — those are outlined in one iteration and the counter runs
on — but on two table expressions in **one** statement, which take separate
iterations:

```
Variable name "<temp1>" already defined
lv_text = |{ <temp1>-name }{ <temp1>-name }|.    <-- reads the same row twice
```

A `fieldSymbol` flag that both decorates the name and checks the decorated
spelling is the whole change. `moveWithTableTarget` decorated after the fact and
carried the same latent defect; it takes the flag now.

## Tests

Six existing expectations move to the new output — fixture text, not assertions
about semantics. Two tests are added for what this is actually about: the
reference case, and two outlines in one statement getting distinct field symbols.
Both emitted programs were checked with `SyntaxLogic`: no issues.

Whole core suite **10935 → 10937 passing, 0 failing**; `npm run lint` clean.
Diff is 16/8 lines of source and 86/21 of test.

One numbering shifts where a `DATA temp1` already exists: the row placeholder
becomes `<temp1>` rather than `<temp2>`, because the collision check now looks up
`<temp1>` and that is a different identifier from `temp1` in ABAP.

## Risk

`ASSIGNING` binds the field symbol to the row for as long as it lives, where
`INTO` took a snapshot. The outlined read is inserted immediately before the
statement that consumes it, so there is no window in which the table can be
modified in between — except a statement that reads and modifies the same table
at once, which is where the two lowerings would genuinely differ.

The narrower alternative is to assign only when the outlined value is consumed in
a reference position, but the rule does not carry that context at the point of the
rewrite, and the write path already assigns unconditionally.

## Where this bites

abap2UI5's cell binding, `_bind( val = tab[ n ]-comp tab = tab tab_index = n )`,
identifies the bound cell by data reference and refuses a `val` that is not a
component of the addressed row. After the downport that refusal fires on correct
code, so the binding is unusable in every downported build. Nothing reports it:
the source is valid at the v750 target, abaplint is green on the downported
branch, and the failure is a runtime exception on a system.

Closest prior art is #2452 (*"Downport: table expression assignment fails"*);
#2335 and #1549 are the neighbouring reports, all closed and none of them this
case.